### PR TITLE
Ports Allied G.I units deploy into sandbags w/ MG

### DIFF
--- a/rules/allied-infantry.yaml
+++ b/rules/allied-infantry.yaml
@@ -95,7 +95,9 @@ e1:
 	Health:
 		HP: 125
 	Mobile:
-		Speed: 31
+		UpgradeTypes: undeployed
+		UpgradeMinEnabledLevel: 1
+		Speed: 41
 	Passenger:
 		PipType: Green
 	RevealsShroud:
@@ -106,26 +108,38 @@ e1:
 		Weapon: M60
 		UpgradeTypes: eliteweapon
 		UpgradeMaxEnabledLevel: 0
-		UpgradeMaxAcceptedLevel: 1
+		UpgradeMaxAcceptedLevel: 0
 	Armament@elite:
 		Weapon: M60E
-		UpgradeTypes: eliteweapon
+		UpgradeTypes: eliteweapon, undeployed
 		UpgradeMinEnabledLevel: 1
-#	Armament@deployed:
-#		Weapon: para
-#		UpgradeTypes: deployed
-#		UpgradeMinEnabledLevel: 1
-#	Armament@elite-deployed:
-#		Weapon: paraE
-#		UpgradeTypes: eliteparaweapon
-#		UpgradeMinEnabledLevel: 1
-	WithInfantryBody:
+	Armament@deployed:
+		Weapon: para
+		UpgradeTypes: deployed
+		UpgradeMinEnabledLevel: 1
+	Armament@elite-deployed:
+		Weapon: paraE
+		UpgradeTypes: deployed, eliteweapon
+		UpgradeMinEnabledLevel: 1
 	Voiced:
 		VoiceSet: GIVoice
 	ProducibleWithLevel:
 		Prerequisites: barracks.infiltrated
 	QuantizeFacingsFromSequence:
 		Sequence: stand
+	DeployToUpgrade:
+		DeployedUpgrades: deployed, notmobile
+		UndeployedUpgrades: undeployed
+		DeployAnimation: deploy
+		DeploySound: igidepa.wav
+		UndeploySound: igidepb.wav
+	WithInfantryBody:
+		UpgradeTypes: undeployed
+		UpgradeMinEnabledLevel: 1
+	WithFacingSpriteBody@DEPLOYED:
+		Sequence: deployed
+		UpgradeTypes: undeployed
+		UpgradeMaxEnabledLevel: 0
 
 snipe:
 	Inherits: ^Infantry


### PR DESCRIPTION
Also increases their speed to the normal RA2 speed, as they were going way too slow compared to RA2 GIs.
![524775b2-a773-11e5-91f3-8834495ae27c](https://cloud.githubusercontent.com/assets/4081722/11943070/e8650c9a-a7ef-11e5-957e-ac11a72f9fa8.png)

Ports deploying Allied G.I. units into their sandbag mode.