### PR TITLE
Fixes Engineers to use proper RA2 capturing

### DIFF
--- a/rules/allied-infantry.yaml
+++ b/rules/allied-infantry.yaml
@@ -20,6 +20,7 @@ engineer:
 	EngineerRepair:
 	RepairsBridges:
 	Captures:
+		Sabotage: false
 		CaptureTypes: building, husk
 	-AutoTarget:
 	WithInfantryBody:


### PR DESCRIPTION
They now capture buildings they are inserted into instead of sabotaging them.