### PR TITLE
Adds the Soviet Sentry Gun.

### DIFF
--- a/rules/soviet-structures.yaml
+++ b/rules/soviet-structures.yaml
@@ -665,3 +665,41 @@ tesla:
 		Sequence: idle-powered
 		PauseOnLowPower: true
 
+nalasr:
+	Inherits: ^VoxelLighting
+	Buildable:
+		Queue: Support
+		BuildPaletteOrder: 30
+		Prerequisites: barracks, ~structures.soviets
+	Valued:
+		Cost: 500
+	Tooltip:
+		Name: Sentry Gun
+		Description: Automated anti-infantry defense.
+	Building:
+		Footprint: x
+		Dimensions: 1, 1
+	Health:
+		HP: 400
+	Armor:
+		Type: Steel
+	RevealsShroud:
+		Range: 7c0
+	Selectable:
+		Bounds: 50, 30, 0, -4
+	Turreted:
+		ROT: 10
+		InitialFacing: 224
+		Offset: 450,0,0
+	AttackTurreted:
+		Voice: Attack
+	Armament:
+		Weapon: vulcan
+	BodyOrientation:
+		QuantizedFacings: 16
+	RenderVoxels:
+	WithVoxelTurret:
+	WithRangeCircle:
+		Range: 6c0
+		Type: pillbox
+	AutoTarget:

--- a/sequences/soviet-structures.yaml
+++ b/sequences/soviet-structures.yaml
@@ -525,6 +525,27 @@ nawall:
 		UseTilesetCode: false
 
 nalasr:
+	Defaults:
+		Offset: 0, -20
+		UseTilesetCode: true
+		TilesetOverrides:
+			TEMPERAT: GENERIC
+			URBAN: GENERIC
+	idle: nalasr
+		ShadowStart: 3
+	damaged-idle: nalasr
+		Start: 1
+		ShadowStart: 4
+	critical-idle: nalasr
+		Start: 2
+		ShadowStart: 5
+	make: nalasrmk
+		Length: 9
+		ShadowStart: 9
+		TilesetOverrides:
+			TEMPERAT: TEMPERAT
+			URBAN: URBAN
+		ZOffset: 0
 	icon: plticon
 		Offset: 0,0
 		UseTilesetCode: false

--- a/weapons.yaml
+++ b/weapons.yaml
@@ -1059,6 +1059,33 @@ SuperComet:
 	Warhead@4Smu: LeaveSmudge
 		SmudgeType: SmallCrater, SmallScorch
 
+vulcan:
+	ReloadDelay: 26
+	Range: 5c512
+	Report: bsenatta.wav, bsenattb.wav bsenattc.wav bsenattd.wav
+	Projectile: Bullet
+		Speed: 100c0
+	Warhead@1Dam: SpreadDamage
+		Spread: 64
+		Damage: 50
+		Versus:
+			None: 100
+			Flak: 80
+			Plate: 70
+			Light: 50
+			Medium: 25
+			Heavy: 25
+			Wood: 75
+			Steel: 50
+			Concrete: 25
+		DamageTypes: Prone70Percent, TriggerProne, BulletDeath
+	Warhead@2Eff: CreateEffect
+		Explosion: piff
+		InvalidImpactTypes: Water
+	Warhead@3EffWater: CreateEffect
+		Explosion: piff
+		ValidImpactTypes: Water
+
 vulcan2:
 	ReloadDelay: 26
 	Range: 5c512


### PR DESCRIPTION
![2015-12-22_18-18-26](https://cloud.githubusercontent.com/assets/4081722/11970017/7aa44f74-a8d8-11e5-9c8d-0a4547815d71.png)
Adds the Soviet Sentry Gun base defense.

Pretty much just a pill box for the soviets, as it was in original RA2.