### PR TITLE
Fix other Side's Naval Unit Cameos are visible.

### DIFF
--- a/rules/allied-naval.yaml
+++ b/rules/allied-naval.yaml
@@ -3,7 +3,7 @@ lcrf:
 	Buildable:
 		Queue: Ship
 		BuildPaletteOrder: 10
-		Prerequisites: gayard
+		Prerequisites: ~gayard
 	Valued:
 		Cost: 900
 	Tooltip:
@@ -50,7 +50,7 @@ dest:
 	Buildable:
 		Queue: Ship
 		BuildPaletteOrder: 40
-		Prerequisites: gayard
+		Prerequisites: ~gayard
 	Valued:
 		Cost: 1000
 	Tooltip:

--- a/rules/soviet-naval.yaml
+++ b/rules/soviet-naval.yaml
@@ -3,7 +3,7 @@ sapc:
 	Buildable:
 		Queue: Ship
 		BuildPaletteOrder: 10
-		Prerequisites: nayard
+		Prerequisites: ~nayard
 	Valued:
 		Cost: 900
 	Tooltip:
@@ -48,7 +48,7 @@ sub:
 	Buildable:
 		Queue: Ship
 		BuildPaletteOrder: 30
-		Prerequisites: nayard
+		Prerequisites: ~nayard
 	Valued:
 		Cost: 1000
 	Tooltip:
@@ -104,7 +104,7 @@ hyd:
 	Buildable:
 		Queue: Ship
 		BuildPaletteOrder: 20
-		Prerequisites: naradr, nayard
+		Prerequisites: naradr, ~nayard
 	Valued:
 		Cost: 900
 	Tooltip:


### PR DESCRIPTION
All except aegis was missing of "~" on their `Prerequisite:`.