### PR TITLE
Add "TechLevel: Unrestricted" to "LobbyDefaults:"

### DIFF
--- a/mod.yaml
+++ b/mod.yaml
@@ -199,6 +199,7 @@ LobbyDefaults:
 	Shroud: true
 	Fog: true
 	ShortGame: false
+	TechLevel: Unrestricted
 
 ChromeMetrics:
 	./mods/ra2/metrics.yaml


### PR DESCRIPTION
I know we don't have tech levels here yet but it was showning `none` on tech levels if not selected.