### PR TITLE
Setup the undeploy cursor for construction yards

### DIFF
--- a/rules/allied-structures.yaml
+++ b/rules/allied-structures.yaml
@@ -27,6 +27,7 @@ gacnst:
 		IntoActor: amcv
 		Offset: 1,1
 		Facing: 96
+		DeployCursor: undeploy
 	ProductionBar@Building:
 		ProductionType: Building
 	ProductionBar@Support:

--- a/rules/soviet-structures.yaml
+++ b/rules/soviet-structures.yaml
@@ -29,6 +29,7 @@ nacnst:
 		IntoActor: smcv
 		Offset: 1,1
 		Facing: 96
+		DeployCursor: undeploy
 	ProductionBar@Building:
 		ProductionType: Building
 	ProductionBar@Support:


### PR DESCRIPTION
At the moment it re-uses the deploy ones which is irritating.