### PR TITLE
Add SoundOnDamageTransition to civilian props

### DIFF
--- a/rules/civilian-props.yaml
+++ b/rules/civilian-props.yaml
@@ -1,9 +1,5 @@
 camisc01:
 	Inherits: ^CivBuilding
-	Selectable:
-	Building:
-		Footprint: x
-		Dimensions: 1, 1
 	Tooltip:
 		Name: Barrels
 	Health:
@@ -15,10 +11,6 @@ camisc01:
 
 camisc02:
 	Inherits: ^CivBuilding
-	Selectable:
-	Building:
-		Footprint: x
-		Dimensions: 1, 1
 	Tooltip:
 		Name: Barrel
 	Health:
@@ -30,9 +22,6 @@ camisc02:
 
 camisc03:
 	Inherits: ^CivBuilding
-	Building:
-		Footprint: x
-		Dimensions: 1, 1
 	Tooltip:
 		Name: Dumpster
 	Health:
@@ -45,9 +34,6 @@ camisc03:
 
 camisc04:
 	Inherits: ^CivBuilding
-	Building:
-		Footprint: x
-		Dimensions: 1, 1
 	Tooltip:
 		Name: Mailbox
 	Health:
@@ -118,9 +104,6 @@ camsc13:
 
 calit01e:
 	Inherits: ^CivBuilding
-	Building:
-		Footprint: x
-		Dimensions: 1, 1
 	Tooltip:
 		Name: Light
 	Health:
@@ -130,9 +113,6 @@ calit01e:
 
 calit01w:
 	Inherits: ^CivBuilding
-	Building:
-		Footprint: x
-		Dimensions: 1, 1
 	Tooltip:
 		Name: Light
 	Health:
@@ -142,9 +122,6 @@ calit01w:
 
 capol01w:
 	Inherits: ^CivBuilding
-	Building:
-		Footprint: x
-		Dimensions: 1, 1
 	Tooltip:
 		Name: Telephone Pole
 	Health:

--- a/rules/civilian-props.yaml
+++ b/rules/civilian-props.yaml
@@ -10,6 +10,8 @@ camisc01:
 		HP: 5
 	Armor:
 		Type: Concrete
+	SoundOnDamageTransition:
+		DamagedSounds:  bmetdama.wav, bmetdamb.wav, bmetdamc.wav
 
 camisc02:
 	Inherits: ^CivBuilding
@@ -23,6 +25,8 @@ camisc02:
 		HP: 5
 	Armor:
 		Type: Concrete
+	SoundOnDamageTransition:
+		DamagedSounds:  bmetdama.wav, bmetdamb.wav, bmetdamc.wav
 
 camisc03:
 	Inherits: ^CivBuilding
@@ -35,6 +39,9 @@ camisc03:
 		HP: 100
 	Armor:
 		Type: Concrete
+	SoundOnDamageTransition:
+		DamagedSounds:  bmetdama.wav, bmetdamb.wav, bmetdamc.wav
+		DestroyedSounds: bmetdama.wav, bmetdamb.wav, bmetdamc.wav
 
 camisc04:
 	Inherits: ^CivBuilding
@@ -47,6 +54,9 @@ camisc04:
 		HP: 10
 	Armor:
 		Type: Concrete
+	SoundOnDamageTransition:
+		DamagedSounds:  bmetdama.wav, bmetdamb.wav, bmetdamc.wav
+		DestroyedSounds: bmetdama.wav, bmetdamb.wav, bmetdamc.wav
 
 camisc05:
 	Inherits: ^CivBuilding
@@ -56,6 +66,9 @@ camisc05:
 		HP: 10
 	Armor:
 		Type: Concrete
+	SoundOnDamageTransition:
+		DamagedSounds:  bmetdama.wav, bmetdamb.wav, bmetdamc.wav
+		DestroyedSounds: bmetdama.wav, bmetdamb.wav, bmetdamc.wav
 
 camisc06:
 	Inherits: ^CivBuilding
@@ -70,6 +83,8 @@ camisc06:
 		Type: Concrete
 	WithBuildingExplosion:
 		Sequences: terrorist_explosion
+	SoundOnDamageTransition:
+		DamagedSounds:  bmetdama.wav, bmetdamb.wav, bmetdamc.wav
 
 camsc11:
 	Inherits: ^CivBuilding
@@ -136,4 +151,3 @@ capol01w:
 		HP: 20
 	Armor:
 		Type: Concrete
-

--- a/rules/defaults.yaml
+++ b/rules/defaults.yaml
@@ -178,6 +178,9 @@
 		Range: 6c0
 	WithIdleOverlay@flag:
 		Sequence: flag
+	SoundOnDamageTransition:
+		DamagedSounds:  bmetdama.wav, bmetdamb.wav, bmetdamc.wav
+		DestroyedSounds: bmetdama.wav, bmetdamb.wav, bmetdamc.wav
 
 ^VoxelLighting:
 	Inherits: ^SupportBuilding


### PR DESCRIPTION
Adds `SoundOnDamageTransition` where I found it.
rules.ini:
```
DamageSound=BuildingMetalDamaged
DieSound=BuildingMetalDamaged
```
and sound.ini:
```
[BuildingMetalDamaged]
Sounds=bmetdama bmetdamb bmetdamc
```

For some reason (the explosion sounds?) some of them only had `DamageSound` defined, so I kept it that way. In addition I did some cleanup and removed some values that are already inherited (see https://github.com/OpenRA/ra2/pull/20#discussion_r49741770).

Follow-up of #20.