### PR TITLE
Fix the turret offsets of the Sentry Gun and the Patriot Missile System

### DIFF
--- a/rules/allied-structures.yaml
+++ b/rules/allied-structures.yaml
@@ -508,7 +508,7 @@ nasam:
 	Turreted:
 		ROT: 10
 		InitialFacing: 224
-		Offset: 900,0,0
+		Offset: 550,0,0
 	AttackTurreted:
 		Voice: Attack
 	Armament:

--- a/rules/soviet-structures.yaml
+++ b/rules/soviet-structures.yaml
@@ -685,11 +685,11 @@ nalasr:
 	RevealsShroud:
 		Range: 7c0
 	Selectable:
-		Bounds: 50, 30, 0, -4
+		Bounds: 50, 30, 0, -12
 	Turreted:
 		ROT: 10
 		InitialFacing: 224
-		Offset: 450,0,0
+		Offset: 320,0,0
 	AttackTurreted:
 		Voice: Attack
 	Armament:


### PR DESCRIPTION
I used those wiki pages to confirm the offsets:
http://cnc.wikia.com/wiki/Sentry_Gun_(Red_Alert_2)
http://cnc.wikia.com/wiki/Patriot_missile_system_(Red_Alert)

They might not be perfect though.