### PR TITLE
Fix a crash in the install logic

### DIFF
--- a/mod.yaml
+++ b/mod.yaml
@@ -183,8 +183,9 @@ LoadScreen: LogoStripeLoadScreen
 ContentInstaller:
 	TestFiles: ^Content/ra2/ra2.mix, ^Content/ra2/language.mix
 	# TODO: Installing from CD doesn't work (because CAB)
-	#PackageToExtractFromCD: INSTALL\Game1.CAB:CRC32
-	#ExtractFilesFromCD: ra2.mix, language.mix, theme.mix,
+	PackageToExtractFromCD: INSTALL\Game1.CAB:CRC32
+	ExtractFilesFromCD:
+		.: THEME.mix, ra2.mix, language.mix
 
 ServerTraits:
 	LobbyCommands


### PR DESCRIPTION
Fixes #55.

Results in this now:
![ra2fetchassets](https://cloud.githubusercontent.com/assets/7704140/12391277/d25473b6-bde6-11e5-939f-2d36e793ffdc.png)
