### PR TITLE
Further polish to the powerdown indicator

### DIFF
--- a/cursors.yaml
+++ b/cursors.yaml
@@ -273,7 +273,7 @@ Cursors:
 			Start: 73
 			Length: 5
 		powerdown-blocked:
-			Start: 52
+			Start: 342
 		joystick-all:
 			Start: 385
 		joystick-t-blocked:

--- a/sequences/misc.yaml
+++ b/sequences/misc.yaml
@@ -17,6 +17,8 @@ poweroff:
 	offline: poweroff
 		Length: *
 		Tick: 160
+		Offset: 0,-50
+		ZOffset: 2047
 
 allyrepair:
 	repair: wrench


### PR DESCRIPTION
The blocked animation looked weird (too small). I could use the green color instead of the light blue if wished. The next thing is that the powerdown indicator was below the offline building.
![ra2powerdown](https://cloud.githubusercontent.com/assets/7704140/12457687/3c04131e-bfa6-11e5-86a5-7b3eb4cc5775.png)
