### PR TITLE
Add proper sounds to the iron curtain

### DIFF
--- a/rules/soviet-structures.yaml
+++ b/rules/soviet-structures.yaml
@@ -540,10 +540,9 @@ nairon:
 		Description: Invulnerability
 		LongDesc: Makes a group of units invulnerable\nfor 20 seconds.
 		Duration: 500
-		SelectTargetSound:
-		InsufficientPowerSound:
-		BeginChargeSound:
-		EndChargeSound:
+		# TODO: This are actually no speech notifications
+		EndChargeSound: siroread.wav
+		GrantUpgradeSound: siroon.wav
 		DisplayRadarPing: True
 		Upgrades: invulnerability
 	SupportPowerChargeBar:


### PR DESCRIPTION
Also removed dummy-empty sound definitions, they are null by default.

```
[IronCurtainBlast]
Sounds= siroon

[IronCurtainReady]
Sounds=siroread
```