### PR TITLE
Fix naclon being able to produce Infantry on its own

### DIFF
--- a/rules/soviet-structures.yaml
+++ b/rules/soviet-structures.yaml
@@ -470,7 +470,7 @@ naclon:
 		SpawnOffset: 410,140,0
 		ExitCell: 2,0
 	Production:
-		Produces: Infantry
+		Produces:
 	RallyPoint:
 	ClonesProducedUnits:
 		CloneableTypes: infantry


### PR DESCRIPTION
Fixes also following bug:
- Build a barracks
- Build a cloning vats
- Produce infantry

-> They will only come out of the cloning vats until you make the barracks primary.

The empty `Produces` is required as this field has `[FieldLoader.Require]`.