### PR TITLE
Add missing IsWater entries to all tilesets

### DIFF
--- a/tilesets/snow.yaml
+++ b/tilesets/snow.yaml
@@ -32,6 +32,7 @@ Terrain:
 		Type: Water
 		Color: 745537
 		TargetTypes: Water
+		IsWater: True
 	TerrainType@DirtRoad:
 		Type: DirtRoad
 		AcceptsSmudgeType: SmallCrater, MediumCrater, LargeCrater, SmallScorch, MediumScorch, LargeScorch

--- a/tilesets/temperat.yaml
+++ b/tilesets/temperat.yaml
@@ -32,6 +32,7 @@ Terrain:
 		Type: Water
 		Color: 745537
 		TargetTypes: Water
+		IsWater: True
 	TerrainType@DirtRoad:
 		Type: DirtRoad
 		AcceptsSmudgeType: SmallCrater, MediumCrater, LargeCrater, SmallScorch, MediumScorch, LargeScorch

--- a/tilesets/urban.yaml
+++ b/tilesets/urban.yaml
@@ -32,6 +32,7 @@ Terrain:
 		Type: Water
 		Color: 745537
 		TargetTypes: Water
+		IsWater: True
 	TerrainType@DirtRoad:
 		Type: DirtRoad
 		AcceptsSmudgeType: SmallCrater, MediumCrater, LargeCrater, SmallScorch, MediumScorch, LargeScorch


### PR DESCRIPTION
Noticed during the review of #40.

Note: It doesn't fix our "crates don't display their water animation" issue.