### PR TITLE
Some fixes about Tesla Trooper

### DIFF
--- a/rules/soviet-infantry.yaml
+++ b/rules/soviet-infantry.yaml
@@ -94,11 +94,12 @@ shk:
 		Queue: Infantry
 		BuildAtProductionType: Infantry
 		Prerequisites: ~nahand
+		BuildPaletteOrder: 30
 	Valued:
 		Cost: 500
 	Tooltip:
-		Name: Shock Trooper
-		Description: Special armored unit using electricity.\n  Strong vs Infantry, Light armor\n  Weak vs Tanks, Aircraft\nSpecial ability: Charge tesla coils (3 Tesla Troopers required)
+		Name: Tesla Trooper
+		Description: Special armored unit using electricity.\n  Strong vs Infantry, Light armor\n  Weak vs Tanks, Aircraft\nSpecial ability: Charge tesla coils
 	Selectable:
 		Bounds: 20, 30, 0, -11
 	Health:


### PR DESCRIPTION
Fixes its name, build palette order and description. One Tesla Trooper can charge a coil, but 2 is required for powering them under low power.