### PR TITLE
Fix Spies can enter all Buildings

### DIFF
--- a/rules/allied-structures.yaml
+++ b/rules/allied-structures.yaml
@@ -82,10 +82,14 @@ gapowr:
 		Sequence: idle-glow
 	Power:
 		Amount: 200
+	InfiltrateForPowerOutage:
+	AffectedByPowerOutage:
 	ScalePowerWithHealth:
 	SoundOnDamageTransition:
 		DestroyedSounds: bpowdiea.wav, bpowdieb.wav
 	PowerTooltip:
+	Targetable:
+		TargetTypes: Ground, C4, DetonateAttack, Structure, SpyInfiltrate
 
 gapile:
 	Inherits: ^Building
@@ -181,6 +185,9 @@ garefn:
 		Capacity: 999999
 	CustomSellValue:
 		Value: 300
+	InfiltrateForCash:
+		Percentage: 50
+		Notification: CreditsStolen
 	FreeActor:
 		Actor: cmin
 		SpawnOffset: 4, 1
@@ -192,6 +199,8 @@ garefn:
 		Sequence: idle-drill
 	Power:
 		Amount: -50
+	Targetable:
+		TargetTypes: Ground, C4, DetonateAttack, Structure, SpyInfiltrate
 
 gaairc:
 	Inherits: ^Building
@@ -240,7 +249,7 @@ gaairc:
 		Sequence: idle-dish
 		PauseOnLowPower: true
 	Targetable:
-		TargetTypes: Ground, C4, SpyInfiltrate, DetonateAttack
+		TargetTypes: Ground, C4, DetonateAttack, Structure, SpyInfiltrate
 	Power:
 		Amount: -50
 	Reservable:

--- a/rules/defaults.yaml
+++ b/rules/defaults.yaml
@@ -73,7 +73,7 @@
 	Selectable:
 		Priority: 3
 	Targetable:
-		TargetTypes: Ground, C4, DetonateAttack, SpyInfiltrate
+		TargetTypes: Ground, C4, DetonateAttack, Structure
 	Building:
 		Dimensions: 1,1
 		Footprint: x

--- a/rules/soviet-structures.yaml
+++ b/rules/soviet-structures.yaml
@@ -75,10 +75,14 @@ napowr:
 		Sequence: idle-lights
 	Power:
 		Amount: 150
+	InfiltrateForPowerOutage:
+	AffectedByPowerOutage:
 	ScalePowerWithHealth:
 	SoundOnDamageTransition:
 		DestroyedSounds: bpowdiea.wav, bpowdieb.wav
 	PowerTooltip:
+	Targetable:
+		TargetTypes: Ground, C4, DetonateAttack, Structure, SpyInfiltrate
 
 nahand:
 	Inherits: ^Building
@@ -168,6 +172,9 @@ narefn:
 		Capacity: 999999
 	CustomSellValue:
 		Value: 300
+	InfiltrateForCash:
+		Percentage: 50
+		Notification: CreditsStolen
 	FreeActor:
 		Actor: harv
 		SpawnOffset: 4, 1
@@ -179,6 +186,8 @@ narefn:
 		Sequence: idle-drill
 	Power:
 		Amount: -50
+	Targetable:
+		TargetTypes: Ground, C4, DetonateAttack, Structure, SpyInfiltrate
 
 naradr:
 	Inherits: ^Building
@@ -213,7 +222,7 @@ naradr:
 		Sequence: idle-dish
 		PauseOnLowPower: true
 	Targetable:
-		TargetTypes: Ground, C4, SpyInfiltrate, DetonateAttack
+		TargetTypes: Ground, C4, DetonateAttack, Structure, SpyInfiltrate
 	InfiltrateForExploration:
 	Power:
 		Amount: -50
@@ -405,10 +414,14 @@ nanrct:
 		EmptyWeapon: NukePayload
 	Power:
 		Amount: 2000
+	InfiltrateForPowerOutage:
+	AffectedByPowerOutage:
 	ScalePowerWithHealth:
 	SoundOnDamageTransition:
 		DestroyedSounds: bpowdiea.wav, bpowdieb.wav
 	PowerTooltip:
+	Targetable:
+		TargetTypes: Ground, C4, DetonateAttack, Structure, SpyInfiltrate
 
 natech:
 	Inherits: ^Building


### PR DESCRIPTION
Now they only enter what they supposed to enter except the SWs because something like `InfiltrateForSWTimerReset:` is not added yet iirc.