### PR TITLE
Added transparency for underwater units

### DIFF
--- a/rules/allied-naval.yaml
+++ b/rules/allied-naval.yaml
@@ -172,6 +172,7 @@ dlph:
 		UncloakSound: vnavupa.wav
 		WhileCloakedUpgrades: underwater
 		UncloakOn: Damage
+		IsPlayerPalette: true
 	Targetable:
 		TargetTypes: Ground, Water
 		UpgradeTypes: underwater

--- a/rules/palettes.yaml
+++ b/rules/palettes.yaml
@@ -67,16 +67,10 @@
 		G: 0
 		B: 0
 		A: 140
-	PaletteFromRGBA@cloak:
-		Name: cloak
-		R: 0
-		G: 0
-		B: 0
-		A: 140
 	PaletteFromPlayerPaletteWithAlpha@cloak:
 		BaseName: cloak
 		BasePalette: player
-		Alpha: 0.55
+		Alpha: 0.50
 	PaletteFromRGBA@invuln:
 		Name: invuln
 		R: 128

--- a/rules/soviet-naval.yaml
+++ b/rules/soviet-naval.yaml
@@ -75,6 +75,7 @@ sub:
 		CloakSound: vnavupa.wav
 		UncloakSound: vnavupa.wav
 		WhileCloakedUpgrades: underwater
+		IsPlayerPalette: true
 	Armament:
 		Weapon: SubTorpedo
 		LocalOffset: 768,0,0


### PR DESCRIPTION
Red Alert 2 used pre-multiplied alpha for this not a fixed palette like RA95.