### PR TITLE
Add missing PlayerStanceColor* definitions to metrics.yaml

### DIFF
--- a/metrics.yaml
+++ b/metrics.yaml
@@ -44,4 +44,7 @@ Metrics:
 	IncompatibleGameStartedColor: D2691E
 	GlobalChatTextColor: FFFFFF
 	GlobalChatNotificationColor: D3D3D3
-
+	PlayerStanceColorSelf: 32CD32
+	PlayerStanceColorAllies: FFFF00
+	PlayerStanceColorEnemies: FF0000
+	PlayerStanceColorNeutrals: D2B48C


### PR DESCRIPTION
Fixes #96. Those definitions were added in https://github.com/OpenRA/OpenRA/pull/10649.