### PR TITLE
Fixed harvesters spawning too far from their refinery

### DIFF
--- a/rules/allied-structures.yaml
+++ b/rules/allied-structures.yaml
@@ -190,7 +190,7 @@ garefn:
 		Notification: CreditsStolen
 	FreeActor:
 		Actor: cmin
-		SpawnOffset: 4, 1
+		SpawnOffset: 3, 1
 		Facing: 160
 	WithDockedOverlay:
 	WithIdleOverlay@bib:

--- a/rules/soviet-structures.yaml
+++ b/rules/soviet-structures.yaml
@@ -177,7 +177,7 @@ narefn:
 		Notification: CreditsStolen
 	FreeActor:
 		Actor: harv
-		SpawnOffset: 4, 1
+		SpawnOffset: 3, 1
 		Facing: 160
 	WithDockedOverlay:
 	WithIdleOverlay@bib:


### PR DESCRIPTION
as done for Tiberian Sun in https://github.com/OpenRA/OpenRA/pull/10573.