### PR TITLE
Fixed ingame-diplomacy.yaml not found crash

### DIFF
--- a/mod.yaml
+++ b/mod.yaml
@@ -110,7 +110,6 @@ ChromeLayout:
 	./mods/ra/chrome/ingame.yaml
 	./mods/d2k/chrome/ingame-observer.yaml
 	./mods/ra/chrome/ingame-chat.yaml
-	./mods/ra/chrome/ingame-diplomacy.yaml
 	./mods/ra/chrome/ingame-fmvplayer.yaml
 	./mods/ra/chrome/ingame-menu.yaml
 	./mods/ra/chrome/ingame-info.yaml


### PR DESCRIPTION
as per https://github.com/OpenRA/OpenRA/pull/10650.