### PR TITLE
Added missing civilian buildings and props

### DIFF
--- a/maps/powdrkeg/map.yaml
+++ b/maps/powdrkeg/map.yaml
@@ -12,7 +12,7 @@ Tileset: URBAN
 
 MapSize: 120,250
 
-Bounds: 4,5,111,228
+Bounds: 4,5,111,238
 
 Visibility: Lobby
 
@@ -75,1868 +75,2936 @@ Players:
 		Enemies: Creeps
 
 Actors:
-	Actor0: cawash10
+	Actor0: capars11
+		Location: 121,-2
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor1: cawash18
+		Location: 123,-9
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor2: cawash18
+		Location: 129,-3
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor3: cawash18
+		Location: 124,7
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor4: cawash18
+		Location: 129,1
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor5: caeuro05
+		Location: 115,6
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor6: caeuro05
+		Location: 115,-8
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor7: caeuro05
+		Location: 128,-8
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor8: caeuro05
+		Location: 128,6
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor9: cawash18
+		Location: 119,-9
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor10: cawash18
+		Location: 114,-3
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor11: cawash18
+		Location: 114,1
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor12: cawash18
+		Location: 120,7
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor13: carus02g
+		Location: 131,-10
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor14: carus02g
+		Location: 113,-10
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor15: carus02g
+		Location: 113,9
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor16: carus02g
+		Location: 131,9
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor17: carus02b
+		Location: 112,1
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor18: carus02b
+		Location: 112,-2
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor19: carus02b
+		Location: 132,1
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor20: carus02b
+		Location: 132,-2
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor21: carus02a
+		Location: 121,10
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor22: carus02a
+		Location: 124,10
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor23: carus02a
+		Location: 123,-11
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor24: carus02a
+		Location: 120,-11
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor25: capars02
+		Location: 172,-17
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor26: capars09
+		Location: 143,-17
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor27: capars09
+		Location: 107,29
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor28: carus04
+		Location: 156,14
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor29: carus04
+		Location: 123,40
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor30: carus05
+		Location: 117,30
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor31: canewy06
+		Location: 104,37
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor32: canewy08
+		Location: 68,16
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor33: cawash10
 		Location: 75,18
 		Owner: Neutral
 		Health: 100
 		Facing: 96
-	Actor1: cawash11
+	Actor34: cawash11
 		Location: 74,27
 		Owner: Neutral
 		Health: 100
 		Facing: 96
-	Actor2: cawash11
+	Actor35: cawash11
 		Location: 153,-17
 		Owner: Neutral
 		Health: 100
 		Facing: 96
-	Actor3: cawash04
+	Actor36: cawash04
 		Location: 83,3
 		Owner: Neutral
 		Health: 100
 		Facing: 96
-	Actor4: cawash05
+	Actor37: cawash05
 		Location: 97,42
 		Owner: Neutral
 		Health: 100
 		Facing: 96
-	Actor5: cawash05
+	Actor38: cawash05
 		Location: 153,-8
 		Owner: Neutral
 		Health: 100
 		Facing: 96
-	Actor6: cawash05
+	Actor39: cawash05
 		Location: 82,-15
 		Owner: Neutral
 		Health: 100
 		Facing: 96
-	Actor7: cawash07
+	Actor40: cawash06
+		Location: 84,19
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor41: cawash07
 		Location: 110,43
 		Owner: Neutral
 		Health: 100
 		Facing: 96
-	Actor8: cawash07
+	Actor42: cawash07
 		Location: 134,31
 		Owner: Neutral
 		Health: 100
 		Facing: 96
-	Actor9: cawash07
+	Actor43: cawash07
 		Location: 162,-2
 		Owner: Neutral
 		Health: 100
 		Facing: 96
-	Actor10: cawash09
+	Actor44: cawash08
+		Location: 145,-1
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor45: camiam07
+		Location: 171,24
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor46: cawash09
 		Location: 106,22
 		Owner: Neutral
 		Health: 100
 		Facing: 96
-	Actor11: cawash10
+	Actor47: cahse02
+		Location: 60,20
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor48: cahse03
+		Location: 60,13
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor49: cahse04
+		Location: 60,6
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor50: cahse05
+		Location: 92,-6
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor51: camsc04
+		Location: 95,-3
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor52: camsc05
+		Location: 94,-6
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor53: camsc05
+		Location: 97,-9
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor54: camsc02
+		Location: 97,-3
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor55: camsc02
+		Location: 94,-7
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor56: camsc02
+		Location: 96,-9
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor57: camsc03
+		Location: 94,-3
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor58: cachig03
+		Location: 155,7
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor59: cachig03
+		Location: 162,-8
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+#	Actor60: catech01
+#		Location: 162,-26
+#		Owner: Neutral
+#		Health: 100
+#		Facing: 96
+	Actor61: calab
+		Location: 170,5
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor62: cagas01
+		Location: 76,-6
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor63: camsc01
+		Location: 94,-10
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor64: camsc01
+		Location: 99,-6
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor65: camsc10
+		Location: 92,3
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor66: camiam01
+		Location: 117,23
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor67: camiam02
+		Location: 126,-18
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor68: camiam03
+		Location: 138,-6
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor69: camiam06
+		Location: 60,27
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor70: canewy10
+		Location: 117,17
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor71: canewy12
+		Location: 138,4
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor72: canewy13
+		Location: 136,20
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor73: canewy14
+		Location: 127,16
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor74: canewy15
+		Location: 83,35
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor75: canewy16
+		Location: 142,15
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor76: canewy17
+		Location: 135,13
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor77: canewy18
+		Location: 136,-16
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor78: canwy23
+		Location: 104,-7
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor79: canwy23
+		Location: 91,35
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor80: canwy24
+		Location: 96,30
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor81: canwy24
+		Location: 135,-29
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor82: canwy26
+		Location: 124,-32
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor83: canwy26
+		Location: 105,-16
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor84: capars10
+		Location: 104,15
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor85: capars13
+		Location: 171,-26
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor86: capars14
+		Location: 173,-2
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor87: caswst01
+		Location: 114,-31
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor88: caswst01
+		Location: 85,-7
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor89: caswst01
+		Location: 84,28
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor90: castl02
+		Location: 116,40
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor91: castl01
+		Location: 127,22
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor92: catexs07
+		Location: 145,-8
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor93: catexs08
+		Location: 154,-2
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor94: catexs06
+		Location: 164,14
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor95: catexs06
+		Location: 104,3
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor96: catexs07
+		Location: 116,-25
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor97: capars09
+		Location: 146,8
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor98: capars02
+		Location: 103,-30
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor99: camiam01
+		Location: 69,6
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor100: camiam03
+		Location: 75,3
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor101: canewy10
+		Location: 70,-15
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor102: canewy16
+		Location: 133,41
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor103: canwy23
+		Location: 173,-8
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor104: canwy26
+		Location: 143,-48
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor105: castl01
+		Location: 125,-25
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor106: castl02
+		Location: 135,-41
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor107: canewy06
+		Location: 141,-57
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor108: canewy07
+		Location: 128,-41
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor109: cawash10
 		Location: 94,22
 		Owner: Neutral
 		Health: 100
 		Facing: 96
-	Actor12: cawash05
+	Actor110: cawash05
 		Location: 135,-50
 		Owner: Neutral
 		Health: 100
 		Facing: 96
-	Actor13: cawash04
+	Actor111: canewy16
+		Location: 89,42
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor112: camiam05
+		Location: 85,-25
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor113: camsc10
+		Location: 148,-26
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor114: caind01
+		Location: 147,-62
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor115: cawash04
 		Location: 94,-27
 		Owner: Neutral
 		Health: 100
 		Facing: 96
-	Actor14: tree01
+	Actor116: suvb
+		Location: 59,21
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor117: stang
+		Location: 61,17
+		Owner: Neutral
+		Health: 100
+		Facing: 160
+	Actor118: suvw
+		Location: 59,6
+		Owner: Neutral
+		Health: 100
+		Facing: 96
+	Actor119: lt_eur01
+		Location: 125,3
+		Owner: Neutral
+	Actor120: lt_eur01
+		Location: 125,-4
+		Owner: Neutral
+	Actor121: lt_eur01
+		Location: 119,-4
+		Owner: Neutral
+	Actor122: lt_eur01
+		Location: 119,3
+		Owner: Neutral
+	Actor123: lt_eur01
+		Location: 129,4
+		Owner: Neutral
+	Actor124: lt_eur01
+		Location: 129,-5
+		Owner: Neutral
+	Actor125: lt_eur01
+		Location: 115,4
+		Owner: Neutral
+	Actor126: lt_eur01
+		Location: 114,-5
+		Owner: Neutral
+	Actor127: lt_eur02
+		Location: 127,7
+		Owner: Neutral
+	Actor128: lt_eur02
+		Location: 118,7
+		Owner: Neutral
+	Actor129: lt_eur02
+		Location: 117,-9
+		Owner: Neutral
+	Actor130: lt_eur02
+		Location: 126,-8
+		Owner: Neutral
+	Actor131: tree01
 		Location: 124,6
 		Owner: Neutral
-	Actor15: tree01
+	Actor132: tree01
 		Location: 125,6
 		Owner: Neutral
-	Actor16: tree01
+	Actor133: tree01
 		Location: 126,5
 		Owner: Neutral
-	Actor17: tree01
+	Actor134: tree01
 		Location: 127,4
 		Owner: Neutral
-	Actor18: tree01
+	Actor135: tree01
 		Location: 128,3
 		Owner: Neutral
-	Actor19: tree01
+	Actor136: tree01
 		Location: 128,2
 		Owner: Neutral
-	Actor20: tree01
+	Actor137: tree01
 		Location: 128,1
 		Owner: Neutral
-	Actor21: tree01
+	Actor138: tree01
 		Location: 127,3
 		Owner: Neutral
-	Actor22: tree01
+	Actor139: tree01
 		Location: 126,4
 		Owner: Neutral
-	Actor23: tree01
+	Actor140: tree01
 		Location: 125,5
 		Owner: Neutral
-	Actor24: tree01
+	Actor141: tree01
 		Location: 121,6
 		Owner: Neutral
-	Actor25: tree01
+	Actor142: tree01
 		Location: 120,6
 		Owner: Neutral
-	Actor26: tree01
+	Actor143: tree01
 		Location: 119,6
 		Owner: Neutral
-	Actor27: tree01
+	Actor144: tree01
 		Location: 119,5
 		Owner: Neutral
-	Actor28: tree01
+	Actor145: tree01
 		Location: 118,5
 		Owner: Neutral
-	Actor29: tree01
+	Actor146: tree01
 		Location: 118,4
 		Owner: Neutral
-	Actor30: tree01
+	Actor147: tree01
 		Location: 117,4
 		Owner: Neutral
-	Actor31: tree01
+	Actor148: tree01
 		Location: 117,3
 		Owner: Neutral
-	Actor32: tree01
+	Actor149: tree01
 		Location: 116,3
 		Owner: Neutral
-	Actor33: tree01
+	Actor150: tree01
 		Location: 116,2
 		Owner: Neutral
-	Actor34: tree01
+	Actor151: tree01
 		Location: 116,1
 		Owner: Neutral
-	Actor35: tree01
+	Actor152: tree01
 		Location: 116,-2
 		Owner: Neutral
-	Actor36: tree01
+	Actor153: tree01
 		Location: 116,-3
 		Owner: Neutral
-	Actor37: tree01
+	Actor154: tree01
 		Location: 116,-4
 		Owner: Neutral
-	Actor38: tree01
+	Actor155: tree01
 		Location: 117,-4
 		Owner: Neutral
-	Actor39: tree01
+	Actor156: tree01
 		Location: 117,-5
 		Owner: Neutral
-	Actor40: tree01
+	Actor157: tree01
 		Location: 118,-5
 		Owner: Neutral
-	Actor41: tree01
+	Actor158: tree01
 		Location: 118,-6
 		Owner: Neutral
-	Actor42: tree01
+	Actor159: tree01
 		Location: 119,-6
 		Owner: Neutral
-	Actor43: tree01
+	Actor160: tree01
 		Location: 119,-7
 		Owner: Neutral
-	Actor44: tree01
+	Actor161: tree01
 		Location: 120,-7
 		Owner: Neutral
-	Actor45: tree01
+	Actor162: tree01
 		Location: 123,-7
 		Owner: Neutral
-	Actor46: tree01
+	Actor163: tree01
 		Location: 124,-7
 		Owner: Neutral
-	Actor47: tree01
+	Actor164: tree01
 		Location: 128,-2
 		Owner: Neutral
-	Actor48: tree01
+	Actor165: tree01
 		Location: 128,-3
 		Owner: Neutral
-	Actor49: tree01
+	Actor166: tree01
 		Location: 125,-7
 		Owner: Neutral
-	Actor50: tree01
+	Actor167: tree01
 		Location: 125,-6
 		Owner: Neutral
-	Actor51: tree01
+	Actor168: tree01
 		Location: 126,-6
 		Owner: Neutral
-	Actor52: tree01
+	Actor169: tree01
 		Location: 126,-5
 		Owner: Neutral
-	Actor53: tree01
+	Actor170: tree01
 		Location: 127,-5
 		Owner: Neutral
-	Actor54: tree01
+	Actor171: tree01
 		Location: 127,-4
 		Owner: Neutral
-	Actor55: tree01
+	Actor172: tree01
 		Location: 128,-4
 		Owner: Neutral
-	Actor56: tree02
+	Actor173: tree02
 		Location: 132,7
 		Owner: Neutral
-	Actor57: tree02
+	Actor174: tree02
 		Location: 129,10
 		Owner: Neutral
-	Actor58: tree02
+	Actor175: tree02
 		Location: 115,10
 		Owner: Neutral
-	Actor59: tree02
+	Actor176: tree02
 		Location: 112,7
 		Owner: Neutral
-	Actor60: tree02
+	Actor177: tree02
 		Location: 112,-8
 		Owner: Neutral
-	Actor61: tree02
+	Actor178: tree02
 		Location: 115,-11
 		Owner: Neutral
-	Actor62: tree02
+	Actor179: tree02
 		Location: 129,-11
 		Owner: Neutral
-	Actor63: tree02
+	Actor180: tree02
 		Location: 132,-8
 		Owner: Neutral
-	Actor64: tibtre01
+	Actor181: tibtre01
 		Location: 84,-46
 		Owner: Neutral
-	Actor65: tibtre01
+	Actor182: tibtre01
 		Location: 92,-51
 		Owner: Neutral
-	Actor66: tibtre01
+	Actor183: tibtre01
 		Location: 113,-63
 		Owner: Neutral
-	Actor67: tibtre01
+	Actor184: tibtre01
 		Location: 124,-69
 		Owner: Neutral
-	Actor68: tibtre01
+	Actor185: tibtre01
 		Location: 163,-35
 		Owner: Neutral
-	Actor69: tibtre01
+	Actor186: tibtre01
 		Location: 153,-46
 		Owner: Neutral
-	Actor70: tibtre01
+	Actor187: tibtre01
 		Location: 193,-20
 		Owner: Neutral
-	Actor71: tibtre01
+	Actor188: tibtre01
 		Location: 184,0
 		Owner: Neutral
-	Actor72: tibtre01
+	Actor189: tibtre01
 		Location: 165,25
 		Owner: Neutral
-	Actor73: tibtre01
+	Actor190: tibtre01
 		Location: 145,34
 		Owner: Neutral
-	Actor74: tibtre01
+	Actor191: tibtre01
 		Location: 114,64
 		Owner: Neutral
-	Actor75: tibtre01
+	Actor192: tibtre01
 		Location: 132,60
 		Owner: Neutral
-	Actor76: tibtre01
+	Actor193: tibtre01
 		Location: 83,46
 		Owner: Neutral
-	Actor77: tibtre01
+	Actor194: tibtre01
 		Location: 64,42
 		Owner: Neutral
-	Actor78: tibtre01
+	Actor195: tibtre01
 		Location: 55,-8
 		Owner: Neutral
-	Actor79: tibtre01
+	Actor196: tibtre01
 		Location: 58,-17
 		Owner: Neutral
-	Actor80: tibtre02
+	Actor197: trff04
+		Location: 99,-19
+		Owner: Neutral
+	Actor198: trff03
+		Location: 102,-19
+		Owner: Neutral
+	Actor199: trff02
+		Location: 102,-22
+		Owner: Neutral
+	Actor200: trff01
+		Location: 99,-22
+		Owner: Neutral
+	Actor201: trff01
+		Location: 120,-22
+		Owner: Neutral
+	Actor202: trff02
+		Location: 123,-22
+		Owner: Neutral
+	Actor203: trff03
+		Location: 123,-19
+		Owner: Neutral
+	Actor204: trff04
+		Location: 120,-19
+		Owner: Neutral
+	Actor205: trff04
+		Location: 139,-19
+		Owner: Neutral
+	Actor206: trff03
+		Location: 142,-19
+		Owner: Neutral
+	Actor207: trff02
+		Location: 142,-22
+		Owner: Neutral
+	Actor208: trff01
+		Location: 139,-22
+		Owner: Neutral
+	Actor209: trff01
+		Location: 157,-22
+		Owner: Neutral
+	Actor210: trff02
+		Location: 160,-22
+		Owner: Neutral
+	Actor211: trff03
+		Location: 160,-19
+		Owner: Neutral
+	Actor212: trff04
+		Location: 157,-19
+		Owner: Neutral
+	Actor213: sign06
+		Location: 141,-43
+		Owner: Neutral
+	Actor214: sign06
+		Location: 151,-20
+		Owner: Neutral
+	Actor215: sign06
+		Location: 133,-47
+		Owner: Neutral
+	Actor216: sign06
+		Location: 119,-34
+		Owner: Neutral
+	Actor217: sign06
+		Location: 111,-34
+		Owner: Neutral
+	Actor218: sign06
+		Location: 73,-11
+		Owner: Neutral
+	Actor219: sign06
+		Location: 168,-28
+		Owner: Neutral
+	Actor220: sign06
+		Location: 159,-28
+		Owner: Neutral
+	Actor221: sign04
+		Location: 141,-29
+		Owner: Neutral
+	Actor222: sign04
+		Location: 141,-35
+		Owner: Neutral
+	Actor223: sign04
+		Location: 127,-48
+		Owner: Neutral
+	Actor224: sign04
+		Location: 122,-27
+		Owner: Neutral
+	Actor225: sign04
+		Location: 91,-31
+		Owner: Neutral
+	Actor226: sign04
+		Location: 91,-21
+		Owner: Neutral
+	Actor227: sign04
+		Location: 80,26
+		Owner: Neutral
+	Actor228: sign04
+		Location: 57,24
+		Owner: Neutral
+	Actor229: sign04
+		Location: 57,9
+		Owner: Neutral
+	Actor230: sign04
+		Location: 57,2
+		Owner: Neutral
+	Actor231: sign04
+		Location: 73,-1
+		Owner: Neutral
+	Actor232: sign05
+		Location: 149,-43
+		Owner: Neutral
+	Actor233: sign06
+		Location: 169,21
+		Owner: Neutral
+	Actor234: sign04
+		Location: 154,11
+		Owner: Neutral
+	Actor235: sign06
+		Location: 154,3
+		Owner: Neutral
+	Actor236: sign06
+		Location: 159,-4
+		Owner: Neutral
+	Actor237: sign05
+		Location: 158,-4
+		Owner: Neutral
+	Actor238: sign04
+		Location: 159,-5
+		Owner: Neutral
+	Actor239: sign03
+		Location: 158,-5
+		Owner: Neutral
+	Actor240: sign03
+		Location: 167,-5
+		Owner: Neutral
+	Actor241: sign04
+		Location: 168,-5
+		Owner: Neutral
+	Actor242: sign05
+		Location: 167,-4
+		Owner: Neutral
+	Actor243: sign06
+		Location: 168,-4
+		Owner: Neutral
+	Actor244: sign06
+		Location: 162,12
+		Owner: Neutral
+	Actor245: sign03
+		Location: 161,11
+		Owner: Neutral
+	Actor246: sign05
+		Location: 141,0
+		Owner: Neutral
+	Actor247: sign03
+		Location: 122,36
+		Owner: Neutral
+	Actor248: sign06
+		Location: 121,37
+		Owner: Neutral
+	Actor249: sign06
+		Location: 129,37
+		Owner: Neutral
+	Actor250: sign05
+		Location: 139,37
+		Owner: Neutral
+	Actor251: sign03
+		Location: 130,36
+		Owner: Neutral
+	Actor252: sign06
+		Location: 140,27
+		Owner: Neutral
+	Actor253: sign05
+		Location: 114,54
+		Owner: Neutral
+	Actor254: sign03
+		Location: 64,24
+		Owner: Neutral
+	Actor255: sign03
+		Location: 72,24
+		Owner: Neutral
+	Actor256: sign04
+		Location: 73,15
+		Owner: Neutral
+	Actor257: sign06
+		Location: 81,16
+		Owner: Neutral
+	Actor258: sign05
+		Location: 90,16
+		Owner: Neutral
+	Actor259: sign03
+		Location: 91,20
+		Owner: Neutral
+	Actor260: sign03
+		Location: 78,9
+		Owner: Neutral
+	Actor261: sign06
+		Location: 79,0
+		Owner: Neutral
+	Actor262: sign04
+		Location: 63,-12
+		Owner: Neutral
+	Actor263: sign05
+		Location: 90,-18
+		Owner: Neutral
+	Actor264: sign05
+		Location: 100,-11
+		Owner: Neutral
+	Actor265: sign03
+		Location: 175,-21
+		Owner: Neutral
+	Actor266: sign04
+		Location: 142,-5
+		Owner: Neutral
+	Actor267: sign04
+		Location: 141,-11
+		Owner: Neutral
+	Actor268: sign06
+		Location: 101,27
+		Owner: Neutral
+	Actor269: sign03
+		Location: 100,26
+		Owner: Neutral
+	Actor270: trff01
+		Location: 121,25
+		Owner: Neutral
+	Actor271: trff02
+		Location: 124,25
+		Owner: Neutral
+	Actor272: trff03
+		Location: 124,28
+		Owner: Neutral
+	Actor273: trff04
+		Location: 121,28
+		Owner: Neutral
+	Actor274: trff04
+		Location: 113,38
+		Owner: Neutral
+	Actor275: trff03
+		Location: 116,38
+		Owner: Neutral
+	Actor276: trff02
+		Location: 116,35
+		Owner: Neutral
+	Actor277: trff01
+		Location: 113,35
+		Owner: Neutral
+	Actor278: trff01
+		Location: 113,25
+		Owner: Neutral
+	Actor279: trff02
+		Location: 116,25
+		Owner: Neutral
+	Actor280: trff03
+		Location: 116,28
+		Owner: Neutral
+	Actor281: trff04
+		Location: 113,28
+		Owner: Neutral
+	Actor282: sign05
+		Location: 79,42
+		Owner: Neutral
+	Actor283: sign04
+		Location: 80,41
+		Owner: Neutral
+	Actor284: sign05
+		Location: 79,25
+		Owner: Neutral
+	Actor285: sign06
+		Location: 70,25
+		Owner: Neutral
+	Actor286: sign05
+		Location: 65,38
+		Owner: Neutral
+	Actor287: sign05
+		Location: 79,32
+		Owner: Neutral
+	Actor288: sign03
+		Location: 79,50
+		Owner: Neutral
+	Actor289: sign04
+		Location: 115,46
+		Owner: Neutral
+	Actor290: sign06
+		Location: 121,47
+		Owner: Neutral
+	Actor291: sign03
+		Location: 120,46
+		Owner: Neutral
+	Actor292: sign05
+		Location: 128,47
+		Owner: Neutral
+	Actor293: sign03
+		Location: 128,55
+		Owner: Neutral
+	Actor294: sign06
+		Location: 131,27
+		Owner: Neutral
+	Actor295: trff01
+		Location: 88,25
+		Owner: Neutral
+	Actor296: trff02
+		Location: 91,25
+		Owner: Neutral
+	Actor297: trff03
+		Location: 91,28
+		Owner: Neutral
+	Actor298: trff04
+		Location: 88,28
+		Owner: Neutral
+	Actor299: trff04
+		Location: 63,11
+		Owner: Neutral
+	Actor300: trff03
+		Location: 66,11
+		Owner: Neutral
+	Actor301: trff02
+		Location: 66,8
+		Owner: Neutral
+	Actor302: trff01
+		Location: 63,8
+		Owner: Neutral
+	Actor303: sign06
+		Location: 73,10
+		Owner: Neutral
+	Actor304: trff04
+		Location: 89,11
+		Owner: Neutral
+	Actor305: trff03
+		Location: 92,11
+		Owner: Neutral
+	Actor306: trff02
+		Location: 92,8
+		Owner: Neutral
+	Actor307: trff01
+		Location: 89,8
+		Owner: Neutral
+	Actor308: trff01
+		Location: 89,-2
+		Owner: Neutral
+	Actor309: trff01
+		Location: 89,-13
+		Owner: Neutral
+	Actor310: trff01
+		Location: 99,-2
+		Owner: Neutral
+	Actor311: trff02
+		Location: 92,-13
+		Owner: Neutral
+	Actor312: trff02
+		Location: 92,-2
+		Owner: Neutral
+	Actor313: trff02
+		Location: 102,-2
+		Owner: Neutral
+	Actor314: trff03
+		Location: 102,1
+		Owner: Neutral
+	Actor315: trff03
+		Location: 92,-10
+		Owner: Neutral
+	Actor316: trff03
+		Location: 92,1
+		Owner: Neutral
+	Actor317: trff04
+		Location: 89,-10
+		Owner: Neutral
+	Actor318: trff04
+		Location: 99,1
+		Owner: Neutral
+	Actor319: trff04
+		Location: 89,1
+		Owner: Neutral
+	Actor320: trff04
+		Location: 99,11
+		Owner: Neutral
+	Actor321: trff03
+		Location: 102,11
+		Owner: Neutral
+	Actor322: trff02
+		Location: 102,8
+		Owner: Neutral
+	Actor323: trff01
+		Location: 99,8
+		Owner: Neutral
+	Actor324: trff01
+		Location: 99,19
+		Owner: Neutral
+	Actor325: trff02
+		Location: 102,19
+		Owner: Neutral
+	Actor326: trff03
+		Location: 102,22
+		Owner: Neutral
+	Actor327: trff04
+		Location: 99,22
+		Owner: Neutral
+	Actor328: trff04
+		Location: 166,4
+		Owner: Neutral
+	Actor329: trff03
+		Location: 169,4
+		Owner: Neutral
+	Actor330: trff02
+		Location: 169,1
+		Owner: Neutral
+	Actor331: trff01
+		Location: 166,1
+		Owner: Neutral
+	Actor332: trff01
+		Location: 166,-12
+		Owner: Neutral
+	Actor333: trff02
+		Location: 169,-12
+		Owner: Neutral
+	Actor334: trff03
+		Location: 169,-9
+		Owner: Neutral
+	Actor335: trff04
+		Location: 166,-9
+		Owner: Neutral
+	Actor336: trff04
+		Location: 166,-19
+		Owner: Neutral
+	Actor337: trff03
+		Location: 169,-19
+		Owner: Neutral
+	Actor338: trff02
+		Location: 169,-22
+		Owner: Neutral
+	Actor339: trff01
+		Location: 166,-22
+		Owner: Neutral
+	Actor340: trff01
+		Location: 157,-12
+		Owner: Neutral
+	Actor341: trff01
+		Location: 149,-12
+		Owner: Neutral
+	Actor342: trff01
+		Location: 157,1
+		Owner: Neutral
+	Actor343: trff01
+		Location: 149,-6
+		Owner: Neutral
+	Actor344: trff02
+		Location: 152,-12
+		Owner: Neutral
+	Actor345: trff02
+		Location: 152,-6
+		Owner: Neutral
+	Actor346: trff02
+		Location: 160,1
+		Owner: Neutral
+	Actor347: trff02
+		Location: 160,-12
+		Owner: Neutral
+	Actor348: trff03
+		Location: 160,-9
+		Owner: Neutral
+	Actor349: trff03
+		Location: 152,-9
+		Owner: Neutral
+	Actor350: trff03
+		Location: 152,-3
+		Owner: Neutral
+	Actor351: trff03
+		Location: 160,4
+		Owner: Neutral
+	Actor352: trff04
+		Location: 157,4
+		Owner: Neutral
+	Actor353: trff04
+		Location: 149,-3
+		Owner: Neutral
+	Actor354: trff04
+		Location: 149,-9
+		Owner: Neutral
+	Actor355: trff04
+		Location: 157,-9
+		Owner: Neutral
+	Actor356: sign06
+		Location: 115,21
+		Owner: Neutral
+	Actor357: sign03
+		Location: 114,20
+		Owner: Neutral
+	Actor358: sign06
+		Location: 96,0
+		Owner: Neutral
+	Actor359: sign03
+		Location: 95,9
+		Owner: Neutral
+	Actor360: sign06
+		Location: 123,21
+		Owner: Neutral
+	Actor361: sign03
+		Location: 122,20
+		Owner: Neutral
+	Actor362: tibtre02
 		Location: 163,7
 		Owner: Neutral
-	Actor81: tibtre02
+	Actor363: tibtre02
 		Location: 163,-16
 		Owner: Neutral
-	Actor82: tibtre02
+	Actor364: tibtre02
 		Location: 133,-25
 		Owner: Neutral
-	Actor83: tibtre02
+	Actor365: tibtre02
 		Location: 96,-16
 		Owner: Neutral
-	Actor84: tibtre02
+	Actor366: tibtre02
 		Location: 96,15
 		Owner: Neutral
-	Actor85: tibtre02
+	Actor367: tibtre02
 		Location: 127,32
 		Owner: Neutral
-	Actor86: tibtre03
+	Actor368: tibtre03
 		Location: 136,53
 		Owner: Neutral
-	Actor87: tibtre03
+	Actor369: tibtre03
 		Location: 117,65
 		Owner: Neutral
-	Actor88: tibtre03
+	Actor370: tibtre03
 		Location: 83,52
 		Owner: Neutral
-	Actor89: tibtre03
+	Actor371: tibtre03
 		Location: 57,33
 		Owner: Neutral
-	Actor90: tibtre03
+	Actor372: tibtre03
 		Location: 57,-13
 		Owner: Neutral
-	Actor91: tibtre03
+	Actor373: tibtre03
 		Location: 61,-16
 		Owner: Neutral
-	Actor92: tibtre03
+	Actor374: tibtre03
 		Location: 84,-36
 		Owner: Neutral
-	Actor93: tibtre03
+	Actor375: tibtre03
 		Location: 96,-49
 		Owner: Neutral
-	Actor94: tibtre03
+	Actor376: tibtre03
 		Location: 116,-67
 		Owner: Neutral
-	Actor95: tibtre03
+	Actor377: tibtre03
 		Location: 119,-70
 		Owner: Neutral
-	Actor96: tibtre03
+	Actor378: tibtre03
 		Location: 168,-34
 		Owner: Neutral
-	Actor97: tibtre03
+	Actor379: tibtre03
 		Location: 158,-41
 		Owner: Neutral
-	Actor98: tibtre03
+	Actor380: tibtre03
 		Location: 196,-16
 		Owner: Neutral
-	Actor99: tibtre03
+	Actor381: tibtre03
 		Location: 183,5
 		Owner: Neutral
-	Actor100: tibtre03
+	Actor382: tibtre03
 		Location: 163,28
 		Owner: Neutral
-	Actor101: tibtre03
+	Actor383: tibtre03
 		Location: 141,32
 		Owner: Neutral
-	Actor102: tree09
+	Actor384: tree09
 		Location: 127,45
 		Owner: Neutral
-	Actor103: tree09
+	Actor385: tree09
 		Location: 122,45
 		Owner: Neutral
-	Actor104: tree09
+	Actor386: tree09
 		Location: 122,38
 		Owner: Neutral
-	Actor105: tree09
+	Actor387: tree09
 		Location: 127,38
 		Owner: Neutral
-	Actor106: tree11
+	Actor388: tree11
 		Location: 133,34
 		Owner: Neutral
-	Actor107: tree10
+	Actor389: tree10
 		Location: 133,35
 		Owner: Neutral
-	Actor108: tree08
+	Actor390: tree08
 		Location: 137,35
 		Owner: Neutral
-	Actor109: tree06
+	Actor391: tree06
 		Location: 137,29
 		Owner: Neutral
-	Actor110: tree05
+	Actor392: tree05
 		Location: 138,31
 		Owner: Neutral
-	Actor111: tree04
+	Actor393: tree04
 		Location: 138,34
 		Owner: Neutral
-	Actor112: tree04
+	Actor394: tree04
 		Location: 134,22
 		Owner: Neutral
-	Actor113: tree03
+	Actor395: tree03
 		Location: 134,24
 		Owner: Neutral
-	Actor114: tree02
+	Actor396: tree02
 		Location: 132,24
 		Owner: Neutral
-	Actor115: tree02
+	Actor397: tree02
 		Location: 140,20
 		Owner: Neutral
-	Actor116: tree01
+	Actor398: tree01
 		Location: 135,40
 		Owner: Neutral
-	Actor117: tree01
+	Actor399: tree01
 		Location: 132,43
 		Owner: Neutral
-	Actor118: tree01
+	Actor400: tree01
 		Location: 135,43
 		Owner: Neutral
-	Actor119: tree01
+	Actor401: tree01
 		Location: 132,40
 		Owner: Neutral
-	Actor120: tree02
+	Actor402: tree02
 		Location: 118,39
 		Owner: Neutral
-	Actor121: tree03
+	Actor403: tree03
 		Location: 116,44
 		Owner: Neutral
-	Actor122: tree04
+	Actor404: tree04
 		Location: 118,45
 		Owner: Neutral
-	Actor123: tree05
+	Actor405: tree05
 		Location: 113,52
 		Owner: Neutral
-	Actor124: tree06
+	Actor406: tree06
 		Location: 109,46
 		Owner: Neutral
-	Actor125: tree07
+	Actor407: tree07
 		Location: 112,48
 		Owner: Neutral
-	Actor126: tree08
+	Actor408: tree08
 		Location: 113,47
 		Owner: Neutral
-	Actor127: tree10
+	Actor409: tree10
 		Location: 112,40
 		Owner: Neutral
-	Actor128: tree11
+	Actor410: tree11
 		Location: 113,42
 		Owner: Neutral
-	Actor129: tree16
+	Actor411: tree16
 		Location: 107,33
 		Owner: Neutral
-	Actor130: tree16
+	Actor412: tree16
 		Location: 112,33
 		Owner: Neutral
-	Actor131: tree18
+	Actor413: tree18
 		Location: 121,34
 		Owner: Neutral
-	Actor132: tree18
+	Actor414: tree18
 		Location: 116,34
 		Owner: Neutral
-	Actor133: tree18
+	Actor415: tree18
 		Location: 121,29
 		Owner: Neutral
-	Actor134: tree18
+	Actor416: tree18
 		Location: 116,29
 		Owner: Neutral
-	Actor135: tree15
+	Actor417: tree15
 		Location: 105,29
 		Owner: Neutral
-	Actor136: tree11
+	Actor418: tree11
 		Location: 103,29
 		Owner: Neutral
-	Actor137: tree10
+	Actor419: tree10
 		Location: 106,41
 		Owner: Neutral
-	Actor138: tree08
+	Actor420: tree08
 		Location: 108,39
 		Owner: Neutral
-	Actor139: tree07
+	Actor421: tree07
 		Location: 104,41
 		Owner: Neutral
-	Actor140: tree06
+	Actor422: tree06
 		Location: 102,37
 		Owner: Neutral
-	Actor141: tree05
+	Actor423: tree05
 		Location: 107,36
 		Owner: Neutral
-	Actor142: tree04
+	Actor424: tree04
 		Location: 102,44
 		Owner: Neutral
-	Actor143: tree03
+	Actor425: tree03
 		Location: 94,44
 		Owner: Neutral
-	Actor144: tree02
+	Actor426: tree02
 		Location: 96,43
 		Owner: Neutral
-	Actor145: tree01
+	Actor427: tree01
 		Location: 100,41
 		Owner: Neutral
-	Actor146: tree02
+	Actor428: tree02
 		Location: 89,36
 		Owner: Neutral
-	Actor147: tree03
+	Actor429: tree03
 		Location: 92,33
 		Owner: Neutral
-	Actor148: tree04
+	Actor430: tree04
 		Location: 93,39
 		Owner: Neutral
-	Actor149: tree05
+	Actor431: tree05
 		Location: 93,41
 		Owner: Neutral
-	Actor150: tree07
+	Actor432: tree07
 		Location: 94,40
 		Owner: Neutral
-	Actor151: tree08
+	Actor433: tree08
 		Location: 95,40
 		Owner: Neutral
-	Actor152: tree08
+	Actor434: tree08
 		Location: 87,44
 		Owner: Neutral
-	Actor153: tree10
+	Actor435: tree10
 		Location: 84,39
 		Owner: Neutral
-	Actor154: tree11
+	Actor436: tree11
 		Location: 83,39
 		Owner: Neutral
-	Actor155: tree12
+	Actor437: tree12
 		Location: 81,40
 		Owner: Neutral
-	Actor156: tree13
+	Actor438: tree13
 		Location: 82,32
 		Owner: Neutral
-	Actor157: tree06
+	Actor439: tree06
 		Location: 87,33
 		Owner: Neutral
-	Actor158: tree05
+	Actor440: tree05
 		Location: 87,28
 		Owner: Neutral
-	Actor159: tree04
+	Actor441: tree04
 		Location: 88,30
 		Owner: Neutral
-	Actor160: tree04
+	Actor442: tree04
 		Location: 93,30
 		Owner: Neutral
-	Actor161: tree02
+	Actor443: tree02
 		Location: 98,35
 		Owner: Neutral
-	Actor162: tree02
+	Actor444: tree02
 		Location: 131,51
 		Owner: Neutral
-	Actor163: tree04
+	Actor445: tree04
 		Location: 132,49
 		Owner: Neutral
-	Actor164: tree05
+	Actor446: tree05
 		Location: 132,53
 		Owner: Neutral
-	Actor165: tree06
+	Actor447: tree06
 		Location: 130,52
 		Owner: Neutral
-	Actor166: tree07
+	Actor448: tree07
 		Location: 132,51
 		Owner: Neutral
-	Actor167: tree08
+	Actor449: tree08
 		Location: 131,48
 		Owner: Neutral
-	Actor168: tree15
+	Actor450: tree15
 		Location: 130,49
 		Owner: Neutral
-	Actor169: tree15
+	Actor451: tree15
 		Location: 125,23
 		Owner: Neutral
-	Actor170: tree12
+	Actor452: tree12
 		Location: 126,24
 		Owner: Neutral
-	Actor171: tree11
+	Actor453: tree11
 		Location: 125,25
 		Owner: Neutral
-	Actor172: tree11
+	Actor454: tree11
 		Location: 121,23
 		Owner: Neutral
-	Actor173: tree10
+	Actor455: tree10
 		Location: 116,24
 		Owner: Neutral
-	Actor174: tree09
+	Actor456: tree09
 		Location: 77,30
 		Owner: Neutral
-	Actor175: tree09
+	Actor457: tree09
 		Location: 74,30
 		Owner: Neutral
-	Actor176: tree08
+	Actor458: tree08
 		Location: 71,28
 		Owner: Neutral
-	Actor177: tree07
+	Actor459: tree07
 		Location: 72,27
 		Owner: Neutral
-	Actor178: tree06
+	Actor460: tree06
 		Location: 63,34
 		Owner: Neutral
-	Actor179: tree05
+	Actor461: tree05
 		Location: 64,36
 		Owner: Neutral
-	Actor180: tree04
+	Actor462: tree04
 		Location: 68,30
 		Owner: Neutral
-	Actor181: tree03
+	Actor463: tree03
 		Location: 58,29
 		Owner: Neutral
-	Actor182: tree02
+	Actor464: tree02
 		Location: 59,31
 		Owner: Neutral
-	Actor183: tree05
+	Actor465: tree05
 		Location: 64,26
 		Owner: Neutral
-	Actor184: tree07
+	Actor466: tree07
 		Location: 66,27
 		Owner: Neutral
-	Actor185: tree08
+	Actor467: tree08
 		Location: 68,27
 		Owner: Neutral
-	Actor186: tree10
+	Actor468: tree10
 		Location: 68,28
 		Owner: Neutral
-	Actor187: tree16
+	Actor469: tree16
 		Location: 58,23
 		Owner: Neutral
-	Actor188: tree16
+	Actor470: tree16
 		Location: 58,22
 		Owner: Neutral
-	Actor189: tree16
+	Actor471: tree16
 		Location: 58,21
 		Owner: Neutral
-	Actor190: tree16
+	Actor472: tree16
 		Location: 58,20
 		Owner: Neutral
-	Actor191: tree16
+	Actor473: tree16
 		Location: 62,19
 		Owner: Neutral
-	Actor192: tree16
+	Actor474: tree16
 		Location: 61,19
 		Owner: Neutral
-	Actor193: tree16
+	Actor475: tree16
 		Location: 60,19
 		Owner: Neutral
-	Actor194: tree16
+	Actor476: tree16
 		Location: 59,19
 		Owner: Neutral
-	Actor195: tree16
+	Actor477: tree16
 		Location: 58,19
 		Owner: Neutral
-	Actor196: tree16
+	Actor478: tree16
 		Location: 63,19
 		Owner: Neutral
-	Actor197: tree15
+	Actor479: tree15
 		Location: 63,22
 		Owner: Neutral
-	Actor198: tree17
+	Actor480: tree17
 		Location: 61,12
 		Owner: Neutral
-	Actor199: tree11
+	Actor481: tree11
 		Location: 63,16
 		Owner: Neutral
-	Actor200: tree08
+	Actor482: tree08
 		Location: 59,15
 		Owner: Neutral
-	Actor201: tree07
+	Actor483: tree07
 		Location: 58,6
 		Owner: Neutral
-	Actor202: tree06
+	Actor484: tree06
 		Location: 63,5
 		Owner: Neutral
-	Actor203: tree04
+	Actor485: tree04
 		Location: 67,22
 		Owner: Neutral
-	Actor204: tree03
+	Actor486: tree03
 		Location: 68,20
 		Owner: Neutral
-	Actor205: tree03
+	Actor487: tree03
 		Location: 70,20
 		Owner: Neutral
-	Actor206: tree03
+	Actor488: tree03
 		Location: 70,14
 		Owner: Neutral
-	Actor207: tree03
+	Actor489: tree03
 		Location: 68,14
 		Owner: Neutral
-	Actor208: tree02
+	Actor490: tree02
 		Location: 67,21
 		Owner: Neutral
-	Actor209: tree04
+	Actor491: tree04
 		Location: 67,11
 		Owner: Neutral
-	Actor210: tree05
+	Actor492: tree05
 		Location: 71,13
 		Owner: Neutral
-	Actor211: tree06
+	Actor493: tree06
 		Location: 71,22
 		Owner: Neutral
-	Actor212: tree06
+	Actor494: tree06
 		Location: 87,24
 		Owner: Neutral
-	Actor213: tree07
+	Actor495: tree07
 		Location: 86,25
 		Owner: Neutral
-	Actor214: tree08
+	Actor496: tree08
 		Location: 88,18
 		Owner: Neutral
-	Actor215: tree10
+	Actor497: tree10
 		Location: 82,25
 		Owner: Neutral
-	Actor216: tree11
+	Actor498: tree11
 		Location: 82,24
 		Owner: Neutral
-	Actor217: tree11
+	Actor499: tree11
 		Location: 83,18
 		Owner: Neutral
-	Actor218: tree12
+	Actor500: tree12
 		Location: 93,25
 		Owner: Neutral
-	Actor219: tree13
+	Actor501: tree13
 		Location: 92,23
 		Owner: Neutral
-	Actor220: tree15
+	Actor502: tree15
 		Location: 99,24
 		Owner: Neutral
-	Actor221: tree18
+	Actor503: tree18
 		Location: 109,22
 		Owner: Neutral
-	Actor222: tree18
+	Actor504: tree18
 		Location: 110,23
 		Owner: Neutral
-	Actor223: tree18
+	Actor505: tree18
 		Location: 109,24
 		Owner: Neutral
-	Actor224: tree18
+	Actor506: tree18
 		Location: 109,25
 		Owner: Neutral
-	Actor225: tree18
+	Actor507: tree18
 		Location: 110,24
 		Owner: Neutral
-	Actor226: tree18
+	Actor508: tree18
 		Location: 110,22
 		Owner: Neutral
-	Actor227: tree18
+	Actor509: tree18
 		Location: 105,25
 		Owner: Neutral
-	Actor228: tree18
+	Actor510: tree18
 		Location: 105,24
 		Owner: Neutral
-	Actor229: tree18
+	Actor511: tree18
 		Location: 104,24
 		Owner: Neutral
-	Actor230: tree18
+	Actor512: tree18
 		Location: 104,23
 		Owner: Neutral
-	Actor231: tree18
+	Actor513: tree18
 		Location: 104,22
 		Owner: Neutral
-	Actor232: tree18
+	Actor514: tree18
 		Location: 105,22
 		Owner: Neutral
-	Actor233: tree18
+	Actor515: tree18
 		Location: 104,25
 		Owner: Neutral
-	Actor234: tree18
+	Actor516: tree18
 		Location: 103,25
 		Owner: Neutral
-	Actor235: tree18
+	Actor517: tree18
 		Location: 102,25
 		Owner: Neutral
-	Actor236: tree18
+	Actor518: tree18
 		Location: 110,25
 		Owner: Neutral
-	Actor237: tree18
+	Actor519: tree18
 		Location: 111,25
 		Owner: Neutral
-	Actor238: tree18
+	Actor520: tree18
 		Location: 112,25
 		Owner: Neutral
-	Actor239: tree09
+	Actor521: tree09
 		Location: 107,19
 		Owner: Neutral
-	Actor240: tree09
+	Actor522: tree09
 		Location: 104,19
 		Owner: Neutral
-	Actor241: tree08
+	Actor523: tree08
 		Location: 104,12
 		Owner: Neutral
-	Actor242: tree07
+	Actor524: tree07
 		Location: 103,16
 		Owner: Neutral
-	Actor243: tree06
+	Actor525: tree06
 		Location: 176,24
 		Owner: Neutral
-	Actor244: tree07
+	Actor526: tree07
 		Location: 175,22
 		Owner: Neutral
-	Actor245: tree08
+	Actor527: tree08
 		Location: 174,23
 		Owner: Neutral
-	Actor246: tree08
+	Actor528: tree08
 		Location: 171,29
 		Owner: Neutral
-	Actor247: tree10
+	Actor529: tree10
 		Location: 173,29
 		Owner: Neutral
-	Actor248: tree11
+	Actor530: tree11
 		Location: 170,26
 		Owner: Neutral
-	Actor249: tree11
+	Actor531: tree11
 		Location: 168,14
 		Owner: Neutral
-	Actor250: tree12
+	Actor532: tree12
 		Location: 164,18
 		Owner: Neutral
-	Actor251: tree13
+	Actor533: tree13
 		Location: 163,19
 		Owner: Neutral
-	Actor252: tree19
+	Actor534: tree19
 		Location: 155,18
 		Owner: Neutral
-	Actor253: tree19
+	Actor535: tree19
 		Location: 160,18
 		Owner: Neutral
-	Actor254: tree19
+	Actor536: tree19
 		Location: 160,13
 		Owner: Neutral
-	Actor255: tree19
+	Actor537: tree19
 		Location: 155,13
 		Owner: Neutral
-	Actor256: tree05
+	Actor538: tree05
 		Location: 144,14
 		Owner: Neutral
-	Actor257: tree05
+	Actor539: tree05
 		Location: 141,17
 		Owner: Neutral
-	Actor258: tree05
+	Actor540: tree05
 		Location: 121,19
 		Owner: Neutral
-	Actor259: tree04
+	Actor541: tree04
 		Location: 120,16
 		Owner: Neutral
-	Actor260: tree03
+	Actor542: tree03
 		Location: 115,17
 		Owner: Neutral
-	Actor261: tree02
+	Actor543: tree02
 		Location: 109,18
 		Owner: Neutral
-	Actor262: tree02
+	Actor544: tree02
 		Location: 73,8
 		Owner: Neutral
-	Actor263: tree01
+	Actor545: tree01
 		Location: 67,7
 		Owner: Neutral
-	Actor264: tree03
+	Actor546: tree03
 		Location: 77,2
 		Owner: Neutral
-	Actor265: tree04
+	Actor547: tree04
 		Location: 71,5
 		Owner: Neutral
-	Actor266: tree05
+	Actor548: tree05
 		Location: 77,8
 		Owner: Neutral
-	Actor267: tree16
+	Actor549: tree16
 		Location: 83,8
 		Owner: Neutral
-	Actor268: tree16
+	Actor550: tree16
 		Location: 82,8
 		Owner: Neutral
-	Actor269: tree16
+	Actor551: tree16
 		Location: 81,8
 		Owner: Neutral
-	Actor270: tree16
+	Actor552: tree16
 		Location: 80,8
 		Owner: Neutral
-	Actor271: tree16
+	Actor553: tree16
 		Location: 80,7
 		Owner: Neutral
-	Actor272: tree16
+	Actor554: tree16
 		Location: 80,6
 		Owner: Neutral
-	Actor273: tree16
+	Actor555: tree16
 		Location: 80,5
 		Owner: Neutral
-	Actor274: tree16
+	Actor556: tree16
 		Location: 80,4
 		Owner: Neutral
-	Actor275: tree16
+	Actor557: tree16
 		Location: 80,3
 		Owner: Neutral
-	Actor276: tree16
+	Actor558: tree16
 		Location: 80,2
 		Owner: Neutral
-	Actor277: tree16
+	Actor559: tree16
 		Location: 80,1
 		Owner: Neutral
-	Actor278: tree16
+	Actor560: tree16
 		Location: 81,1
 		Owner: Neutral
-	Actor279: tree16
+	Actor561: tree16
 		Location: 82,1
 		Owner: Neutral
-	Actor280: tree16
+	Actor562: tree16
 		Location: 83,1
 		Owner: Neutral
-	Actor281: tree16
+	Actor563: tree16
 		Location: 84,1
 		Owner: Neutral
-	Actor282: tree16
+	Actor564: tree16
 		Location: 85,1
 		Owner: Neutral
-	Actor283: tree16
+	Actor565: tree16
 		Location: 86,8
 		Owner: Neutral
-	Actor284: tree16
+	Actor566: tree16
 		Location: 87,8
 		Owner: Neutral
-	Actor285: tree16
+	Actor567: tree16
 		Location: 88,8
 		Owner: Neutral
-	Actor286: tree16
+	Actor568: tree16
 		Location: 89,7
 		Owner: Neutral
-	Actor287: tree16
+	Actor569: tree16
 		Location: 89,6
 		Owner: Neutral
-	Actor288: tree16
+	Actor570: tree16
 		Location: 89,5
 		Owner: Neutral
-	Actor289: tree16
+	Actor571: tree16
 		Location: 89,4
 		Owner: Neutral
-	Actor290: tree16
+	Actor572: tree16
 		Location: 89,3
 		Owner: Neutral
-	Actor291: tree16
+	Actor573: tree16
 		Location: 89,2
 		Owner: Neutral
-	Actor292: tree16
+	Actor574: tree16
 		Location: 88,1
 		Owner: Neutral
-	Actor293: tree16
+	Actor575: tree16
 		Location: 87,1
 		Owner: Neutral
-	Actor294: tree16
+	Actor576: tree16
 		Location: 86,1
 		Owner: Neutral
-	Actor295: tree18
+	Actor577: tree18
 		Location: 124,18
 		Owner: Neutral
-	Actor296: tree18
+	Actor578: tree18
 		Location: 124,16
 		Owner: Neutral
-	Actor297: tree15
+	Actor579: tree15
 		Location: 139,2
 		Owner: Neutral
-	Actor298: tree12
+	Actor580: tree12
 		Location: 141,11
 		Owner: Neutral
-	Actor299: tree11
+	Actor581: tree11
 		Location: 140,9
 		Owner: Neutral
-	Actor300: tree10
+	Actor582: tree10
 		Location: 139,13
 		Owner: Neutral
-	Actor301: tree09
+	Actor583: tree09
 		Location: 136,16
 		Owner: Neutral
-	Actor302: tree09
+	Actor584: tree09
 		Location: 138,14
 		Owner: Neutral
-	Actor303: tree08
+	Actor585: tree08
 		Location: 135,16
 		Owner: Neutral
-	Actor304: tree07
+	Actor586: tree07
 		Location: 130,19
 		Owner: Neutral
-	Actor305: tree06
+	Actor587: tree06
 		Location: 132,19
 		Owner: Neutral
-	Actor306: tree06
+	Actor588: tree06
 		Location: 169,13
 		Owner: Neutral
-	Actor307: tree05
+	Actor589: tree05
 		Location: 169,10
 		Owner: Neutral
-	Actor308: tree04
+	Actor590: tree04
 		Location: 171,11
 		Owner: Neutral
-	Actor309: tree03
+	Actor591: tree03
 		Location: 173,5
 		Owner: Neutral
-	Actor310: tree02
+	Actor592: tree02
 		Location: 177,4
 		Owner: Neutral
-	Actor311: tree01
+	Actor593: tree01
 		Location: 172,0
 		Owner: Neutral
-	Actor312: tree01
+	Actor594: tree01
 		Location: 177,0
 		Owner: Neutral
-	Actor313: tree02
+	Actor595: tree02
 		Location: 170,-7
 		Owner: Neutral
-	Actor314: tree03
+	Actor596: tree03
 		Location: 169,-3
 		Owner: Neutral
-	Actor315: tree04
+	Actor597: tree04
 		Location: 171,1
 		Owner: Neutral
-	Actor316: tree04
+	Actor598: tree04
 		Location: 178,-2
 		Owner: Neutral
-	Actor317: tree04
+	Actor599: tree04
 		Location: 178,-6
 		Owner: Neutral
-	Actor318: tree05
+	Actor600: tree05
 		Location: 178,-8
 		Owner: Neutral
-	Actor319: tree05
+	Actor601: tree05
 		Location: 178,3
 		Owner: Neutral
-	Actor320: tree06
+	Actor602: tree06
 		Location: 172,-6
 		Owner: Neutral
-	Actor321: tree07
+	Actor603: tree07
 		Location: 176,2
 		Owner: Neutral
-	Actor322: tree08
+	Actor604: tree08
 		Location: 166,-2
 		Owner: Neutral
-	Actor323: tree10
+	Actor605: tree10
 		Location: 157,6
 		Owner: Neutral
-	Actor324: tree11
+	Actor606: tree11
 		Location: 156,10
 		Owner: Neutral
-	Actor325: tree12
+	Actor607: tree12
 		Location: 156,5
 		Owner: Neutral
-	Actor326: tree13
+	Actor608: tree13
 		Location: 158,10
 		Owner: Neutral
-	Actor327: tree13
+	Actor609: tree13
 		Location: 161,1
 		Owner: Neutral
-	Actor328: tree14
+	Actor610: tree14
 		Location: 157,-2
 		Owner: Neutral
-	Actor329: tree15
+	Actor611: tree15
 		Location: 152,-2
 		Owner: Neutral
-	Actor330: tree12
+	Actor612: tree12
 		Location: 152,1
 		Owner: Neutral
-	Actor331: tree11
+	Actor613: tree11
 		Location: 156,1
 		Owner: Neutral
-	Actor332: tree10
+	Actor614: tree10
 		Location: 151,16
 		Owner: Neutral
-	Actor333: tree09
+	Actor615: tree09
 		Location: 149,2
 		Owner: Neutral
-	Actor334: tree09
+	Actor616: tree09
 		Location: 149,-1
 		Owner: Neutral
-	Actor335: tree08
+	Actor617: tree08
 		Location: 150,16
 		Owner: Neutral
-	Actor336: tree07
+	Actor618: tree07
 		Location: 150,14
 		Owner: Neutral
-	Actor337: tree06
+	Actor619: tree06
 		Location: 152,18
 		Owner: Neutral
-	Actor338: tree05
+	Actor620: tree05
 		Location: 152,15
 		Owner: Neutral
-	Actor339: tree04
+	Actor621: tree04
 		Location: 144,10
 		Owner: Neutral
-	Actor340: tree04
+	Actor622: tree04
 		Location: 143,1
 		Owner: Neutral
-	Actor341: tree03
+	Actor623: tree03
 		Location: 146,6
 		Owner: Neutral
-	Actor342: tree02
+	Actor624: tree02
 		Location: 148,4
 		Owner: Neutral
-	Actor343: tree01
+	Actor625: tree01
 		Location: 145,-3
 		Owner: Neutral
-	Actor344: tree02
+	Actor626: tree02
 		Location: 144,7
 		Owner: Neutral
-	Actor345: tree04
+	Actor627: tree04
 		Location: 107,1
 		Owner: Neutral
-	Actor346: tree02
+	Actor628: tree02
 		Location: 105,8
 		Owner: Neutral
-	Actor347: tree03
+	Actor629: tree03
 		Location: 106,7
 		Owner: Neutral
-	Actor348: tree01
+	Actor630: tree01
 		Location: 102,5
 		Owner: Neutral
-	Actor349: tree01
+	Actor631: tree01
 		Location: 102,2
 		Owner: Neutral
-	Actor350: tree04
+	Actor632: tree04
 		Location: 103,7
 		Owner: Neutral
-	Actor351: tree05
+	Actor633: tree05
 		Location: 109,13
 		Owner: Neutral
-	Actor352: tree06
+	Actor634: tree06
 		Location: 111,14
 		Owner: Neutral
-	Actor353: tree07
+	Actor635: tree07
 		Location: 109,11
 		Owner: Neutral
-	Actor354: tree08
+	Actor636: tree08
 		Location: 112,16
 		Owner: Neutral
-	Actor355: tree05
+	Actor637: tree05
 		Location: 87,-4
 		Owner: Neutral
-	Actor356: tree05
+	Actor638: tree05
 		Location: 87,-8
 		Owner: Neutral
-	Actor357: tree04
+	Actor639: tree04
 		Location: 83,-7
 		Owner: Neutral
-	Actor358: tree03
+	Actor640: tree03
 		Location: 83,-3
 		Owner: Neutral
-	Actor359: tree02
+	Actor641: tree02
 		Location: 84,-3
 		Owner: Neutral
-	Actor360: tree03
+	Actor642: tree03
 		Location: 74,-10
 		Owner: Neutral
-	Actor361: tree05
+	Actor643: tree05
 		Location: 81,-7
 		Owner: Neutral
-	Actor362: tree06
+	Actor644: tree06
 		Location: 81,-9
 		Owner: Neutral
-	Actor363: tree07
+	Actor645: tree07
 		Location: 84,-2
 		Owner: Neutral
-	Actor364: tree06
+	Actor646: tree06
 		Location: 88,-15
 		Owner: Neutral
-	Actor365: tree05
+	Actor647: tree05
 		Location: 85,-16
 		Owner: Neutral
-	Actor366: tree04
+	Actor648: tree04
 		Location: 87,-14
 		Owner: Neutral
-	Actor367: tree17
+	Actor649: tree17
 		Location: 76,-15
 		Owner: Neutral
-	Actor368: tree17
+	Actor650: tree17
 		Location: 82,-13
 		Owner: Neutral
-	Actor369: tree17
+	Actor651: tree17
 		Location: 85,-13
 		Owner: Neutral
-	Actor370: tree15
+	Actor652: tree15
 		Location: 79,-13
 		Owner: Neutral
-	Actor371: tree13
+	Actor653: tree13
 		Location: 66,-14
 		Owner: Neutral
-	Actor372: tree12
+	Actor654: tree12
 		Location: 67,-14
 		Owner: Neutral
-	Actor373: tree11
+	Actor655: tree11
 		Location: 68,-15
 		Owner: Neutral
-	Actor374: tree10
+	Actor656: tree10
 		Location: 69,-13
 		Owner: Neutral
-	Actor375: tree08
+	Actor657: tree08
 		Location: 74,-13
 		Owner: Neutral
-	Actor376: tree07
+	Actor658: tree07
 		Location: 75,-13
 		Owner: Neutral
-	Actor377: tree06
+	Actor659: tree06
 		Location: 75,-15
 		Owner: Neutral
-	Actor378: tree06
+	Actor660: tree06
 		Location: 107,-3
 		Owner: Neutral
-	Actor379: tree06
+	Actor661: tree06
 		Location: 103,-3
 		Owner: Neutral
-	Actor380: tree05
+	Actor662: tree05
 		Location: 104,-4
 		Owner: Neutral
-	Actor381: tree05
+	Actor663: tree05
 		Location: 104,-12
 		Owner: Neutral
-	Actor382: tree04
+	Actor664: tree04
 		Location: 103,-14
 		Owner: Neutral
-	Actor383: tree03
+	Actor665: tree03
 		Location: 103,-12
 		Owner: Neutral
-	Actor384: tree02
+	Actor666: tree02
 		Location: 103,-11
 		Owner: Neutral
-	Actor385: tree02
+	Actor667: tree02
 		Location: 110,-17
 		Owner: Neutral
-	Actor386: tree01
+	Actor668: tree01
 		Location: 106,-19
 		Owner: Neutral
-	Actor387: tree01
+	Actor669: tree01
 		Location: 108,-19
 		Owner: Neutral
-	Actor388: tree04
+	Actor670: tree04
 		Location: 111,-18
 		Owner: Neutral
-	Actor389: tree05
+	Actor671: tree05
 		Location: 112,-16
 		Owner: Neutral
-	Actor390: tree07
+	Actor672: tree07
 		Location: 119,-17
 		Owner: Neutral
-	Actor391: tree08
+	Actor673: tree08
 		Location: 119,-18
 		Owner: Neutral
-	Actor392: tree10
+	Actor674: tree10
 		Location: 117,-18
 		Owner: Neutral
-	Actor393: tree11
+	Actor675: tree11
 		Location: 118,-16
 		Owner: Neutral
-	Actor394: tree12
+	Actor676: tree12
 		Location: 116,-17
 		Owner: Neutral
-	Actor395: tree12
+	Actor677: tree12
 		Location: 165,-6
 		Owner: Neutral
-	Actor396: tree12
+	Actor678: tree12
 		Location: 165,-9
 		Owner: Neutral
-	Actor397: tree13
+	Actor679: tree13
 		Location: 161,-6
 		Owner: Neutral
-	Actor398: tree12
+	Actor680: tree12
 		Location: 160,-8
 		Owner: Neutral
-	Actor399: tree12
+	Actor681: tree12
 		Location: 157,-8
 		Owner: Neutral
-	Actor400: tree11
+	Actor682: tree11
 		Location: 152,-7
 		Owner: Neutral
-	Actor401: tree10
+	Actor683: tree10
 		Location: 149,-7
 		Owner: Neutral
-	Actor402: tree08
+	Actor684: tree08
 		Location: 143,-8
 		Owner: Neutral
-	Actor403: tree06
+	Actor685: tree06
 		Location: 140,-2
 		Owner: Neutral
-	Actor404: tree05
+	Actor686: tree05
 		Location: 140,-7
 		Owner: Neutral
-	Actor405: tree05
+	Actor687: tree05
 		Location: 136,-13
 		Owner: Neutral
-	Actor406: tree04
+	Actor688: tree04
 		Location: 134,-14
 		Owner: Neutral
-	Actor407: tree04
+	Actor689: tree04
 		Location: 139,-10
 		Owner: Neutral
-	Actor408: tree01
+	Actor690: tree01
 		Location: 156,-12
 		Owner: Neutral
-	Actor409: tree01
+	Actor691: tree01
 		Location: 153,-12
 		Owner: Neutral
-	Actor410: tree02
+	Actor692: tree02
 		Location: 147,-19
 		Owner: Neutral
-	Actor411: tree03
+	Actor693: tree03
 		Location: 143,-19
 		Owner: Neutral
-	Actor412: tree04
+	Actor694: tree04
 		Location: 143,-12
 		Owner: Neutral
-	Actor413: tree05
+	Actor695: tree05
 		Location: 148,-12
 		Owner: Neutral
-	Actor414: tree06
+	Actor696: tree06
 		Location: 145,-12
 		Owner: Neutral
-	Actor415: tree07
+	Actor697: tree07
 		Location: 147,-12
 		Owner: Neutral
-	Actor416: tree07
+	Actor698: tree07
 		Location: 143,-24
 		Owner: Neutral
-	Actor417: tree08
+	Actor699: tree08
 		Location: 144,-25
 		Owner: Neutral
-	Actor418: tree10
+	Actor700: tree10
 		Location: 147,-22
 		Owner: Neutral
-	Actor419: tree11
+	Actor701: tree11
 		Location: 145,-23
 		Owner: Neutral
-	Actor420: tree15
+	Actor702: tree15
 		Location: 147,-27
 		Owner: Neutral
-	Actor421: tree06
+	Actor703: tree06
 		Location: 146,-25
 		Owner: Neutral
-	Actor422: tree05
+	Actor704: tree05
 		Location: 144,-22
 		Owner: Neutral
-	Actor423: tree05
+	Actor705: tree05
 		Location: 136,-18
 		Owner: Neutral
-	Actor424: tree04
+	Actor706: tree04
 		Location: 136,-31
 		Owner: Neutral
-	Actor425: tree03
+	Actor707: tree03
 		Location: 139,-15
 		Owner: Neutral
-	Actor426: tree03
+	Actor708: tree03
 		Location: 128,-19
 		Owner: Neutral
-	Actor427: tree02
+	Actor709: tree02
 		Location: 132,-18
 		Owner: Neutral
-	Actor428: tree02
+	Actor710: tree02
 		Location: 132,-29
 		Owner: Neutral
-	Actor429: tree01
+	Actor711: tree01
 		Location: 127,-36
 		Owner: Neutral
-	Actor430: tree01
+	Actor712: tree01
 		Location: 128,-37
 		Owner: Neutral
-	Actor431: tree01
+	Actor713: tree01
 		Location: 130,-37
 		Owner: Neutral
-	Actor432: tree01
+	Actor714: tree01
 		Location: 131,-36
 		Owner: Neutral
-	Actor433: tree05
+	Actor715: tree05
 		Location: 138,-30
 		Owner: Neutral
-	Actor434: tree06
+	Actor716: tree06
 		Location: 138,-32
 		Owner: Neutral
-	Actor435: tree06
+	Actor717: tree06
 		Location: 120,-25
 		Owner: Neutral
-	Actor436: tree07
+	Actor718: tree07
 		Location: 115,-28
 		Owner: Neutral
-	Actor437: tree08
+	Actor719: tree08
 		Location: 117,-27
 		Owner: Neutral
-	Actor438: tree09
+	Actor720: tree09
 		Location: 117,-31
 		Owner: Neutral
-	Actor439: tree09
+	Actor721: tree09
 		Location: 117,-29
 		Owner: Neutral
-	Actor440: tree10
+	Actor722: tree10
 		Location: 115,-32
 		Owner: Neutral
-	Actor441: tree11
+	Actor723: tree11
 		Location: 113,-33
 		Owner: Neutral
-	Actor442: tree12
+	Actor724: tree12
 		Location: 113,-23
 		Owner: Neutral
-	Actor443: tree15
+	Actor725: tree15
 		Location: 112,-22
 		Owner: Neutral
-	Actor444: tree11
+	Actor726: tree11
 		Location: 114,-25
 		Owner: Neutral
-	Actor445: tree10
+	Actor727: tree10
 		Location: 114,-24
 		Owner: Neutral
-	Actor446: tree08
+	Actor728: tree08
 		Location: 115,-22
 		Owner: Neutral
-	Actor447: tree05
+	Actor729: tree05
 		Location: 113,-24
 		Owner: Neutral
-	Actor448: tree04
+	Actor730: tree04
 		Location: 111,-22
 		Owner: Neutral
-	Actor449: tree03
+	Actor731: tree03
 		Location: 113,-22
 		Owner: Neutral
-	Actor450: tree03
+	Actor732: tree03
 		Location: 125,-28
 		Owner: Neutral
-	Actor451: tree03
+	Actor733: tree03
 		Location: 127,-28
 		Owner: Neutral
-	Actor452: tree02
+	Actor734: tree02
 		Location: 130,-31
 		Owner: Neutral
-	Actor453: tree04
+	Actor735: tree04
 		Location: 121,-31
 		Owner: Neutral
-	Actor454: tree05
+	Actor736: tree05
 		Location: 121,-32
 		Owner: Neutral
-	Actor455: tree06
+	Actor737: tree06
 		Location: 123,-30
 		Owner: Neutral
-	Actor456: tree07
+	Actor738: tree07
 		Location: 120,-30
 		Owner: Neutral
-	Actor457: tree07
+	Actor739: tree07
 		Location: 124,-23
 		Owner: Neutral
-	Actor458: tree08
+	Actor740: tree08
 		Location: 123,-25
 		Owner: Neutral
-	Actor459: tree08
+	Actor741: tree08
 		Location: 124,-17
 		Owner: Neutral
-	Actor460: tree10
+	Actor742: tree10
 		Location: 123,-16
 		Owner: Neutral
-	Actor461: tree11
+	Actor743: tree11
 		Location: 139,-36
 		Owner: Neutral
-	Actor462: tree11
+	Actor744: tree11
 		Location: 134,-36
 		Owner: Neutral
-	Actor463: tree11
+	Actor745: tree11
 		Location: 134,-46
 		Owner: Neutral
-	Actor464: tree06
+	Actor746: tree06
 		Location: 136,-43
 		Owner: Neutral
-	Actor465: tree05
+	Actor747: tree05
 		Location: 137,-36
 		Owner: Neutral
-	Actor466: tree01
+	Actor748: tree01
 		Location: 89,-21
 		Owner: Neutral
-	Actor467: tree01
+	Actor749: tree01
 		Location: 89,-26
 		Owner: Neutral
-	Actor468: tree05
+	Actor750: tree05
 		Location: 86,-27
 		Owner: Neutral
-	Actor469: tree06
+	Actor751: tree06
 		Location: 84,-21
 		Owner: Neutral
-	Actor470: tree18
+	Actor752: tree18
 		Location: 97,-23
 		Owner: Neutral
-	Actor471: tree18
+	Actor753: tree18
 		Location: 98,-23
 		Owner: Neutral
-	Actor472: tree18
+	Actor754: tree18
 		Location: 98,-24
 		Owner: Neutral
-	Actor473: tree18
+	Actor755: tree18
 		Location: 98,-27
 		Owner: Neutral
-	Actor474: tree18
+	Actor756: tree18
 		Location: 98,-28
 		Owner: Neutral
-	Actor475: tree18
+	Actor757: tree18
 		Location: 97,-28
 		Owner: Neutral
-	Actor476: tree18
+	Actor758: tree18
 		Location: 94,-22
 		Owner: Neutral
-	Actor477: tree18
+	Actor759: tree18
 		Location: 97,-22
 		Owner: Neutral
-	Actor478: tree18
+	Actor760: tree18
 		Location: 99,-24
 		Owner: Neutral
-	Actor479: tree18
+	Actor761: tree18
 		Location: 99,-27
 		Owner: Neutral
-	Actor480: tree18
+	Actor762: tree18
 		Location: 97,-29
 		Owner: Neutral
-	Actor481: tree18
+	Actor763: tree18
 		Location: 94,-23
 		Owner: Neutral
-	Actor482: tree18
+	Actor764: tree18
 		Location: 93,-24
 		Owner: Neutral
-	Actor483: tree18
+	Actor765: tree18
 		Location: 92,-24
 		Owner: Neutral
-	Actor484: tree18
+	Actor766: tree18
 		Location: 93,-23
 		Owner: Neutral
-	Actor485: tree18
+	Actor767: tree18
 		Location: 92,-27
 		Owner: Neutral
-	Actor486: tree18
+	Actor768: tree18
 		Location: 93,-27
 		Owner: Neutral
-	Actor487: tree18
+	Actor769: tree18
 		Location: 93,-28
 		Owner: Neutral
-	Actor488: tree18
+	Actor770: tree18
 		Location: 94,-28
 		Owner: Neutral
-	Actor489: tree18
+	Actor771: tree18
 		Location: 94,-29
 		Owner: Neutral
-	Actor490: tree01
+	Actor772: tree01
 		Location: 106,-22
 		Owner: Neutral
-	Actor491: tree01
+	Actor773: tree01
 		Location: 104,-22
 		Owner: Neutral
-	Actor492: tree02
+	Actor774: tree02
 		Location: 106,-32
 		Owner: Neutral
-	Actor493: tree03
+	Actor775: tree03
 		Location: 102,-26
 		Owner: Neutral
-	Actor494: tree04
+	Actor776: tree04
 		Location: 107,-24
 		Owner: Neutral
-	Actor495: tree05
+	Actor777: tree05
 		Location: 108,-24
 		Owner: Neutral
-	Actor496: tree06
+	Actor778: tree06
 		Location: 109,-32
 		Owner: Neutral
-	Actor497: tree06
+	Actor779: tree06
 		Location: 139,-46
 		Owner: Neutral
-	Actor498: tree06
+	Actor780: tree06
 		Location: 140,-53
 		Owner: Neutral
-	Actor499: tree07
+	Actor781: tree07
 		Location: 135,-48
 		Owner: Neutral
-	Actor500: tree08
+	Actor782: tree08
 		Location: 141,-45
 		Owner: Neutral
-	Actor501: tree09
+	Actor783: tree09
 		Location: 144,-45
 		Owner: Neutral
-	Actor502: tree09
+	Actor784: tree09
 		Location: 146,-45
 		Owner: Neutral
-	Actor503: tree10
+	Actor785: tree10
 		Location: 146,-51
 		Owner: Neutral
-	Actor504: tree11
+	Actor786: tree11
 		Location: 148,-50
 		Owner: Neutral
-	Actor505: tree12
+	Actor787: tree12
 		Location: 132,-49
 		Owner: Neutral
-	Actor506: tree13
+	Actor788: tree13
 		Location: 138,-53
 		Owner: Neutral
-	Actor507: tree14
+	Actor789: tree14
 		Location: 147,-52
 		Owner: Neutral
-	Actor508: tree15
+	Actor790: tree15
 		Location: 145,-53
 		Owner: Neutral
-	Actor509: tree08
+	Actor791: tree08
 		Location: 148,-48
 		Owner: Neutral
-	Actor510: tree07
+	Actor792: tree07
 		Location: 147,-50
 		Owner: Neutral
-	Actor511: tree05
+	Actor793: tree05
 		Location: 142,-46
 		Owner: Neutral
-	Actor512: tree04
+	Actor794: tree04
 		Location: 140,-47
 		Owner: Neutral
-	Actor513: tree04
+	Actor795: tree04
 		Location: 170,-23
 		Owner: Neutral
-	Actor514: tree03
+	Actor796: tree03
 		Location: 174,-22
 		Owner: Neutral
-	Actor515: tree03
+	Actor797: tree03
 		Location: 174,-27
 		Owner: Neutral
-	Actor516: tree02
+	Actor798: tree02
 		Location: 172,-27
 		Owner: Neutral
-	Actor517: tree18
+	Actor799: tree18
 		Location: 166,-24
 		Owner: Neutral
-	Actor518: tree18
+	Actor800: tree18
 		Location: 166,-26
 		Owner: Neutral
-	Actor519: tree14
+	Actor801: tree14
 		Location: 161,-25
 		Owner: Neutral
-	Actor520: tree12
+	Actor802: tree12
 		Location: 164,-22
 		Owner: Neutral
-	Actor521: tree11
+	Actor803: tree11
 		Location: 162,-22
 		Owner: Neutral
-	Actor522: tree10
+	Actor804: tree10
 		Location: 161,-24
 		Owner: Neutral
-	Actor523: tree10
+	Actor805: tree10
 		Location: 129,-44
 		Owner: Neutral
-	Actor524: tree11
+	Actor806: tree11
 		Location: 131,-43
 		Owner: Neutral
-	Actor525: tree12
+	Actor807: tree12
 		Location: 130,-45
 		Owner: Neutral
-	Actor526: tree02
+	Actor808: sign03
+		Location: 132,-35
+		Owner: Neutral
+	Actor809: sign04
+		Location: 133,-35
+		Owner: Neutral
+	Actor810: sign05
+		Location: 132,-34
+		Owner: Neutral
+	Actor811: sign06
+		Location: 133,-34
+		Owner: Neutral
+	Actor812: tree02
 		Location: 76,-9
 		Owner: Neutral
-	Actor527: tree04
+	Actor813: tree04
 		Location: 78,-9
 		Owner: Neutral
-	Actor528: mpspawn
+	Actor814: mpspawn
 		Location: 188,-11
 		Owner: Neutral
-	Actor529: mpspawn
+	Actor815: mpspawn
 		Location: 73,42
 		Owner: Neutral
-	Actor530: mpspawn
+	Actor816: mpspawn
 		Location: 91,-42
 		Owner: Neutral
-	Actor531: mpspawn
+	Actor817: mpspawn
 		Location: 122,54
 		Owner: Neutral
-	Actor532: mpspawn
+	Actor818: mpspawn
 		Location: 152,26
 		Owner: Neutral
-	Actor533: mpspawn
+	Actor819: mpspawn
 		Location: 149,-36
 		Owner: Neutral
-	Actor534: mpspawn
+	Actor820: mpspawn
 		Location: 64,-4
 		Owner: Neutral
-	Actor535: mpspawn
+	Actor821: mpspawn
 		Location: 124,-60
 		Owner: Neutral
-	Actor536: waypoint
+	Actor822: waypoint
 		Location: 131,49
 		Owner: Neutral
-	Actor537: waypoint
+	Actor823: waypoint
 		Location: 94,38
 		Owner: Neutral
-	Actor538: waypoint
+	Actor824: waypoint
 		Location: 67,23
 		Owner: Neutral
-	Actor539: waypoint
+	Actor825: waypoint
 		Location: 110,14
 		Owner: Neutral
-	Actor540: waypoint
+	Actor826: waypoint
 		Location: 82,-6
 		Owner: Neutral
-	Actor541: waypoint
+	Actor827: waypoint
 		Location: 64,-14
 		Owner: Neutral
-	Actor542: waypoint
+	Actor828: waypoint
 		Location: 111,-20
 		Owner: Neutral
-	Actor543: waypoint
+	Actor829: waypoint
 		Location: 106,-11
 		Owner: Neutral
-	Actor544: waypoint
+	Actor830: waypoint
 		Location: 122,-29
 		Owner: Neutral
-	Actor545: waypoint
+	Actor831: waypoint
 		Location: 135,-33
 		Owner: Neutral
-	Actor546: waypoint
+	Actor832: waypoint
 		Location: 143,-52
 		Owner: Neutral
-	Actor547: waypoint
+	Actor833: waypoint
 		Location: 146,-22
 		Owner: Neutral
-	Actor548: waypoint
+	Actor834: waypoint
 		Location: 170,11
 		Owner: Neutral
-	Actor549: waypoint
+	Actor835: waypoint
 		Location: 152,16
 		Owner: Neutral
-	Actor550: waypoint
+	Actor836: waypoint
 		Location: 141,-10
 		Owner: Neutral
-	Actor551: waypoint
+	Actor837: waypoint
 		Location: 132,21
 		Owner: Neutral
-	Actor552: waypoint
+	Actor838: waypoint
 		Location: 176,25
 		Owner: Neutral
-	Actor553: waypoint
+	Actor839: waypoint
 		Location: 110,47
 		Owner: Neutral
-	Actor554: waypoint
+	Actor840: waypoint
 		Location: 100,-21
 		Owner: Neutral
-	Actor555: waypoint
+	Actor841: waypoint
 		Location: 101,20
 		Owner: Neutral
-	Actor556: waypoint
+	Actor842: waypoint
 		Location: 140,18
 		Owner: Neutral
-	Actor557: waypoint
+	Actor843: waypoint
 		Location: 141,-21
 		Owner: Neutral
-	Actor558: waypoint
+	Actor844: waypoint
 		Location: 159,-21
 		Owner: Neutral
-	Actor559: waypoint
+	Actor845: waypoint
 		Location: 159,3
 		Owner: Neutral
-	Actor560: waypoint
+	Actor846: waypoint
 		Location: 123,27
 		Owner: Neutral
-	Actor561: waypoint
+	Actor847: waypoint
 		Location: 90,27
 		Owner: Neutral
-	Actor562: waypoint
+	Actor848: waypoint
 		Location: 65,9
 		Owner: Neutral
-	Actor563: waypoint
+	Actor849: waypoint
 		Location: 91,-12
 		Owner: Neutral
-	Actor564: waypoint
+	Actor850: waypoint
 		Location: 138,-78
 		Owner: Neutral
-	Actor565: waypoint
+	Actor851: waypoint
 		Location: 163,-58
 		Owner: Neutral
-	Actor566: waypoint
+	Actor852: waypoint
 		Location: 173,-43
 		Owner: Neutral
-	Actor567: waypoint
+	Actor853: waypoint
 		Location: 187,-35
 		Owner: Neutral
-	Actor568: waypoint
+	Actor854: waypoint
 		Location: 204,-19
 		Owner: Neutral
-	Actor569: waypoint
+	Actor855: waypoint
 		Location: 206,-1
 		Owner: Neutral
-	Actor570: waypoint
+	Actor856: waypoint
 		Location: 197,9
 		Owner: Neutral
-	Actor571: waypoint
+	Actor857: waypoint
 		Location: 196,25
 		Owner: Neutral
-	Actor572: waypoint
+	Actor858: waypoint
 		Location: 188,39
 		Owner: Neutral
-	Actor573: waypoint
+	Actor859: waypoint
 		Location: 170,42
 		Owner: Neutral
-	Actor574: waypoint
+	Actor860: waypoint
 		Location: 153,45
 		Owner: Neutral
-	Actor575: waypoint
+	Actor861: waypoint
 		Location: 145,60
 		Owner: Neutral
-	Actor576: waypoint
+	Actor862: waypoint
 		Location: 130,73
 		Owner: Neutral
-	Actor577: waypoint
+	Actor863: waypoint
 		Location: 109,79
 		Owner: Neutral
-	Actor578: waypoint
+	Actor864: waypoint
 		Location: 100,58
 		Owner: Neutral
-	Actor579: waypoint
+	Actor865: waypoint
 		Location: 76,63
 		Owner: Neutral
-	Actor580: waypoint
+	Actor866: waypoint
 		Location: 59,47
 		Owner: Neutral
-	Actor581: waypoint
+	Actor867: waypoint
 		Location: 41,24
 		Owner: Neutral
-	Actor582: waypoint
+	Actor868: waypoint
 		Location: 42,5
 		Owner: Neutral
-	Actor583: waypoint
+	Actor869: waypoint
 		Location: 43,-16
 		Owner: Neutral
-	Actor584: waypoint
+	Actor870: waypoint
 		Location: 53,-28
 		Owner: Neutral
-	Actor585: waypoint
+	Actor871: waypoint
 		Location: 69,-35
 		Owner: Neutral
-	Actor586: waypoint
+	Actor872: waypoint
 		Location: 76,-53
 		Owner: Neutral
-	Actor587: waypoint
+	Actor873: waypoint
 		Location: 100,-58
 		Owner: Neutral
-	Actor588: waypoint
+	Actor874: waypoint
 		Location: 111,-47
 		Owner: Neutral
-	Actor589: waypoint
+	Actor875: waypoint
 		Location: 114,-81
 		Owner: Neutral
-	Actor590: waypoint
+	Actor876: waypoint
 		Location: 108,55
 		Owner: Neutral
-	Actor591: waypoint
+	Actor877: waypoint
 		Location: 127,68
 		Owner: Neutral
-	Actor592: waypoint
+	Actor878: waypoint
 		Location: 141,47
 		Owner: Neutral
-	Actor593: waypoint
+	Actor879: waypoint
 		Location: 161,35
 		Owner: Neutral
-	Actor594: waypoint
+	Actor880: waypoint
 		Location: 178,38
 		Owner: Neutral
-	Actor595: waypoint
+	Actor881: waypoint
 		Location: 185,16
 		Owner: Neutral
-	Actor596: waypoint
+	Actor882: waypoint
 		Location: 194,0
 		Owner: Neutral
-	Actor597: waypoint
+	Actor883: waypoint
 		Location: 196,-25
 		Owner: Neutral
-	Actor598: waypoint
+	Actor884: waypoint
 		Location: 176,-35
 		Owner: Neutral
-	Actor599: waypoint
+	Actor885: waypoint
 		Location: 154,-56
 		Owner: Neutral
-	Actor600: waypoint
+	Actor886: waypoint
 		Location: 132,-70
 		Owner: Neutral
-	Actor601: waypoint
+	Actor887: waypoint
 		Location: 109,-68
 		Owner: Neutral
-	Actor602: waypoint
+	Actor888: waypoint
 		Location: 119,-39
 		Owner: Neutral
-	Actor603: waypoint
+	Actor889: waypoint
 		Location: 87,-55
 		Owner: Neutral
-	Actor604: waypoint
+	Actor890: waypoint
 		Location: 82,-36
 		Owner: Neutral
-	Actor605: waypoint
+	Actor891: waypoint
 		Location: 66,-22
 		Owner: Neutral
-	Actor606: waypoint
+	Actor892: waypoint
 		Location: 51,-9
 		Owner: Neutral
-	Actor607: waypoint
+	Actor893: waypoint
 		Location: 48,16
 		Owner: Neutral
-	Actor608: waypoint
+	Actor894: waypoint
 		Location: 58,41
 		Owner: Neutral
-	Actor609: waypoint
+	Actor895: waypoint
 		Location: 76,58
 		Owner: Neutral
-	Actor610: waypoint
+	Actor896: waypoint
 		Location: 94,51
 		Owner: Neutral
-	Actor611: waypoint
+	Actor897: waypoint
 		Location: 123,0
 		Owner: Neutral
 

--- a/mod.yaml
+++ b/mod.yaml
@@ -85,6 +85,7 @@ Sequences:
 	ra2|sequences/allied-structures.yaml
 	ra2|sequences/soviet-structures.yaml
 	ra2|sequences/civilian-structures.yaml
+	ra2|sequences/civilian-props.yaml
 	ra2|sequences/tech-structures.yaml
 	ra2|sequences/vehicles.yaml
 	ra2|sequences/trees.yaml

--- a/rules/civilian-props.yaml
+++ b/rules/civilian-props.yaml
@@ -102,29 +102,372 @@ camsc13:
 	Armor:
 		Type: Concrete
 
-calit01e:
+ammocrat:
 	Inherits: ^CivBuilding
 	Tooltip:
-		Name: Light
+		Name: Ammo Crates
+	Health:
+		HP: 1
+	RenderSprites:
+		Image: ammo01
+
+casin01e:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Roadblock
+	Armor:
+		Type: concrete
+	Health:
+		HP: 5
+
+casin01n:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Roadblock
+	Armor:
+		Type: concrete
+	Health:
+		HP: 5
+
+casin01s:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Roadblock
+	Armor:
+		Type: concrete
+	Health:
+		HP: 5
+
+casin01w:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Roadblock
+	Armor:
+		Type: concrete
+	Health:
+		HP: 5
+
+camsc01:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Hot Dog Stand
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 400
+
+camsc02:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Beach Umbrellas
+	RevealsShroud:
+		Range: 6c0
 	Health:
 		HP: 50
-	Armor:
-		Type: Steel
 
-calit01w:
+camsc03:
 	Inherits: ^CivBuilding
 	Tooltip:
-		Name: Light
+		Name: Beach Umbrellas
+	RevealsShroud:
+		Range: 6c0
 	Health:
-		HP: 50
-	Armor:
-		Type: Steel
+		HP: 1
 
-capol01w:
+camsc04:
 	Inherits: ^CivBuilding
 	Tooltip:
-		Name: Telephone Pole
+		Name: Beach Towels
+	RevealsShroud:
+		Range: 6c0
 	Health:
-		HP: 20
+		HP: 1
+
+camsc05:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Beach TowelsB
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1
+
+camsc06:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Camp Fire
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 10
+
+caeuro05:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Statue
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 400
+	Building:
+		Dimensions: 2,2
+		Footprint: xx xx
+
+capark01:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Park Bench
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1
+
+capark02:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Swing Set
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1
+	Building:
+		Dimensions: 2,1
+		Footprint: xx
+
+capark03:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Merry Go Round
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1
+	Building:
+		Dimensions: 2,2
+		Footprint: xx xx
+
+castrt01:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Traffic Light
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+
+castrt02:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Traffic Light
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+
+castrt03:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Traffic Light
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+
+castrt04:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Traffic Light
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+
+castrt05:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Bus Stop
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+
+camov01:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Drive In Movie Screen
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 500
+	Building:
+		Dimensions: 1,4
+		Footprint: x x x x
+	WithIdleOverlay:
+
+camov02:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Drive In Movie Concession Stand
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 2,2
+		Footprint: xx xx
+	WithIdleOverlay:
+
+pole01:
+	Inherits: ^TelephonePole
+	Tooltip:
+		Name: Utility Pole
+
+pole02:
+	Inherits: ^TelephonePole
+	Tooltip:
+		Name: Utility Pole
+
+hdstn01:
+	Inherits: ^Tree
+	Tooltip:
+		Name: AlringtonStones
+
+lt_gen01:
+	Inherits: ^StreetLight
+
+lt_gen02:
+	Inherits: ^StreetLight
+
+lt_gen03:
+	Inherits: ^StreetLight
+
+lt_gen04:
+	Inherits: ^StreetLight
+
+lt_sgn01:
+	Inherits: ^StreetLight
+
+lt_sgn02:
+	Inherits: ^StreetLight
+
+lt_sgn03:
+	Inherits: ^StreetLight
+
+lt_sgn04:
+	Inherits: ^StreetLight
+
+lt_eur01:
+	Inherits: ^StreetLight
+
+lt_eur02:
+	Inherits: ^StreetLight
+
+trff01:
+	Inherits: ^TrafficLight
+
+trff02:
+	Inherits: ^TrafficLight
+
+trff03:
+	Inherits: ^TrafficLight
+
+trff04:
+	Inherits: ^TrafficLight
+
+sign01:
+	Inherits: ^StreetSign
+
+sign02:
+	Inherits: ^StreetSign
+
+sign03:
+	Inherits: ^StreetSign
+
+sign04:
+	Inherits: ^StreetSign
+
+sign05:
+	Inherits: ^StreetSign
+
+sign06:
+	Inherits: ^StreetSign
+
+spkr01:
+	Inherits: ^Tree
+	Tooltip:
+		Name: Drive-In Speaker
+
+carus02a:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	Health:
+		HP: 800
+
+carus02b:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	Health:
+		HP: 500
+
+carus02c:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: concrete
+	Health:
+		HP: 1000
+
+carus02d:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: concrete
+	Health:
+		HP: 1000
+
+carus02e:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: concrete
+	Health:
+		HP: 1000
+
+carus02f:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: concrete
+	Health:
+		HP: 1000
+
+carus07:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+
+cakrmw:
+	Inherits: ^Wall
+	Tooltip:
+		Name: Kremlin Walls
+		Description: Walls of the Kremlin.
 	Armor:
 		Type: Concrete

--- a/rules/civilian-structures.yaml
+++ b/rules/civilian-structures.yaml
@@ -19,19 +19,129 @@ gasand:
 		DamagedSounds: gsancrua.wav, gsancrub.wav
 		DestroyedSounds: gsancrua.wav, gsancrub.wav
 
+cabhut:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Bridge repair hut
+	Health:
+		HP: 2000
+
 cafncp:
 	Inherits: ^Fence
 	Tooltip:
 		Name: Prison Camp Fence
 		Description: Fence.\nCrushable by vehicles.
 
-cakrmw:
-	Inherits: ^Wall
+cahse01:
+	Inherits: ^CivBuilding
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 600
+	Building:
+		Dimensions: 3,2
+		Footprint: xxx xxx
+
+
+cahse02:
+	Inherits: ^CivBuilding
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 400
+	Building:
+		Dimensions: 3,2
+		Footprint: xxx xxx
+
+cahse03:
+	Inherits: ^CivBuilding
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 400
+	Building:
+		Dimensions: 3,4
+		Footprint: xxx xxx xxx xxx
+
+cahse04:
+	Inherits: ^CivBuilding
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 400
+	Building:
+		Dimensions: 3,2
+		Footprint: xxx xxx
+
+cahse05:
+	Inherits: ^CivBuilding
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 300
+	Building:
+		Dimensions: 1,2
+		Footprint: x x
+
+cahse06:
+	Inherits: ^CivBuilding
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 300
+	Building:
+		Dimensions: 2,1
+		Footprint: xx
+
+cahse07:
+	Inherits: ^CivBuilding
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 600
+	Building:
+		Dimensions: 2,3
+		Footprint: xx xx xx
+
+cawt01:
+	Inherits: ^CivBuilding
 	Tooltip:
-		Name: Kremlin Walls
-		Description: Walls of the Kremlin.
+		Name: Water Tower
 	Armor:
-		Type: Wood
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 400
+	Building:
+		Dimensions: 1,1
+		Footprint: x
+
+cats01:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Twin Silos
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 300
+	Building:
+		Dimensions: 2,2
+		Footprint: xx xx
+
+cabarn02:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Barn
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 500
+	Building:
+		Dimensions: 2,2
+		Footprint: xx xx
 
 cawash01:
 	Inherits: ^CivBuilding
@@ -45,6 +155,19 @@ cawash01:
 		HP: 1000
 	Armor:
 		Type: Concrete
+	RevealsShroud:
+		Range: 6c0
+
+cawash02:
+	Inherits: ^CivBuilding
+	Selectable:
+	Building:
+		Footprint: xxxx xxxx xxxx
+		Dimensions: 4, 3
+	Health:
+		HP: 1000
+	Armor:
+		Type: Steel
 	RevealsShroud:
 		Range: 6c0
 
@@ -87,6 +210,18 @@ cawash05:
 	RevealsShroud:
 		Range: 6c0
 
+cawash06:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 4,4
+		Footprint: xxxx xxxx xxxx xxxx
+
 cawash07:
 	Inherits: ^CivBuilding
 	Selectable:
@@ -99,6 +234,18 @@ cawash07:
 		Type: Steel
 	RevealsShroud:
 		Range: 6c0
+
+cawash08:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 3,4
+		Footprint: xxx xxx xxx xxx
 
 cawash09:
 	Inherits: ^CivBuilding
@@ -139,45 +286,6 @@ cawash11:
 	RevealsShroud:
 		Range: 6c0
 
-cawash13:
-	Inherits: ^CivBuilding
-	Selectable:
-	Building:
-		Footprint: xxxx xxxx xxxx
-		Dimensions: 3, 4
-	Health:
-		HP: 1000
-	Armor:
-		Type: Steel
-	RevealsShroud:
-		Range: 6c0
-
-cawash14:
-	Inherits: ^CivBuilding
-	Selectable:
-	Building:
-		Footprint: xxx xxx xxx
-		Dimensions: 3, 3
-	Tooltip:
-		Name: Jefferson Memorial
-	Health:
-		HP: 1000
-	Armor:
-		Type: Concrete
-
-canewy01:
-	Inherits: ^CivBuilding
-	Selectable:
-	Building:
-		Footprint: xxxx xxxx xxxx xxxx
-		Dimensions: 4, 4
-	Health:
-		HP: 1000
-	Armor:
-		Type: Steel
-	RevealsShroud:
-		Range: 4c0
-
 cawsh12:
 	Inherits: ^CivBuilding
 	Selectable:
@@ -207,6 +315,325 @@ cawsh12:
 		PortYaws: 0, 176, 341, 512, 682, 853
 		PortCones: 86, 86, 86, 86, 86, 86
 
+cawash13:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 3,4
+		Footprint: xxx xxx xxx xxx
+
+cawash14:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Jefferson Memorial
+	Armor:
+		Type: concrete
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 3,3
+		Footprint: xxx xxx xxx
+
+cawash15:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Lincoln Memorial
+	Armor:
+		Type: concrete
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 3,4
+		Footprint: xxx xxx xxx xxx
+
+cawash16:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Smithsonian Castle
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 5,3
+		Footprint: xxxxx xxxxx xxxxx
+
+cawash17:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Smithsonian Natural History Museum
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 6,4
+		Footprint: xxxxxx xxxxxx xxxxxx xxxxxx
+
+cawash18:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: White House Fountain
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 200
+	Building:
+		Dimensions: 2,2
+		Footprint: xx xx
+
+cawash19:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Iwo Jima Memorial
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 500
+	Building:
+		Dimensions: 4,4
+		Footprint: xxxx xxxx xxxx xxxx
+
+canewy01:
+	Inherits: ^CivBuilding
+	Selectable:
+	Building:
+		Footprint: xxxx xxxx xxxx xxxx
+		Dimensions: 4, 4
+	Health:
+		HP: 1000
+	Armor:
+		Type: Steel
+	RevealsShroud:
+		Range: 4c0
+
+canewy04:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Statue of Liberty
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 4c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 3,3
+		Footprint: xxx xxx xxx
+
+canewy05:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: World Trade Center
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 4c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 2,2
+		Footprint: xx xx
+
+canewy06:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 3,3
+		Footprint: xxx xxx xxx
+
+canewy07:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 3,3
+		Footprint: xxx xxx xxx
+
+canewy08:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 3,3
+		Footprint: xxx xxx xxx
+
+canewy10:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 3,2
+		Footprint: xxx xxx
+
+canewy11:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 3,2
+		Footprint: xxx xxx
+
+canewy12:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 2,3
+		Footprint: xx xx xx
+
+canewy13:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 3,3
+		Footprint: xxx xxx xxx
+
+canewy14:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 3,3
+		Footprint: xxx xxx xxx
+
+canewy15:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 3,3
+		Footprint: xxx xxx xxx
+
+canewy16:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 2,2
+		Footprint: xx xx
+
+canewy17:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 2,2
+		Footprint: xx xx
+
+canewy18:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 2,2
+		Footprint: xx xx
+
+canewy20:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Warehouse
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 3,5
+		Footprint: xxx xxx xxx xxx xxx
+
+canewy21:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Warehouse
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 5,3
+		Footprint: xxxxx xxxxx xxxxx
+
+caswst01:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Southwest Building
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 4c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 2,3
+		Footprint: xx xx xx
+
 caarmy01:
 	Inherits: ^CivBuilding
 	Selectable:
@@ -217,10 +644,45 @@ caarmy01:
 		Name: Army Tent
 	Health:
 		HP: 200
-	Armor:
-		Type: Wood
 	RevealsShroud:
 		Range: 6c0
+
+caarmy02:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Army Tent
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 200
+	Building:
+		Dimensions: 1,1
+		Footprint: x
+
+
+caarmy03:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Army Tent
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 200
+	Building:
+		Dimensions: 1,1
+		Footprint: x
+
+caarmy04:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Army Tent
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 200
+	Building:
+		Dimensions: 1,1
+		Footprint: x
 
 cawa2a:
 	Inherits: ^CivBuilding
@@ -292,8 +754,6 @@ cafarm01:
 		Name: Farm
 	Health:
 		HP: 400
-	Armor:
-		Type: Wood
 	RevealsShroud:
 		Range: 4c0
 
@@ -307,8 +767,20 @@ cafarm02:
 		Name: Farm Silo
 	Health:
 		HP: 400
+
+cafarm06:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Lighthouse
 	Armor:
-		Type: Wood
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 500
+	Building:
+		Dimensions: 2,2
+		Footprint: xx xx
 
 causfgl:
 	Inherits: ^Flag
@@ -410,21 +882,1153 @@ cagas01:
 		Name: Gas Station
 	Health:
 		HP: 1000
-	Armor:
-		Type: Wood
 	RevealsShroud:
 		Range: 6c0
 
-catech01:
+galite:
 	Inherits: ^CivBuilding
-	Building:
-		Footprint: xxx xxx xxx
-		Dimensions: 3, 3
 	Tooltip:
-		Name: Communications Center
+		Name: Light Post
+	Valued:
+		Cost: 200
+	RevealsShroud:
+		Range: 0c0
 	Health:
-		HP: 400
+		HP: 600
+	Power:
+		Amount: 0
+	Building:
+		Dimensions: 1,1
+		Footprint: x
+	RenderSprites:
+		Image: galite
+	WithSpriteBody:
+	AutoSelectionSize:
+	BodyOrientation:
+		UseClassicPerspectiveFudge: False
+		QuantizedFacings: 1
+	FrozenUnderFog:
+
+cacity01:
+	Inherits: ^CivBuilding
 	Armor:
-		Type: Steel
+		Type: steel
 	RevealsShroud:
 		Range: 4c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 4,4
+		Footprint: xxxx xxxx xxxx xxxx
+	RenderSprites:
+		PlayerPalette:
+		Palette: city
+
+cacity02:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 4c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 5,4
+		Footprint: xxxxx xxxxx xxxxx xxxxx
+	RenderSprites:
+		PlayerPalette:
+		Palette: city
+
+cacity03:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 4c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 3,3
+		Footprint: xxx xxx xxx
+	RenderSprites:
+		PlayerPalette:
+		Palette: city
+
+cacity04:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 4c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 4,4
+		Footprint: xxxx xxxx xxxx xxxx
+	RenderSprites:
+		PlayerPalette:
+		Palette: city
+
+city05:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Battersea Power Station
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 4c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 4,4
+		Footprint: xxxx xxxx xxxx xxxx
+	RenderSprites:
+		PlayerPalette:
+		Palette: city
+
+catexs01:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 4c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 2,2
+		Footprint: xx xx
+
+
+catexs02:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Alamo
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 2000
+	Building:
+		Dimensions: 4,4
+		Footprint: xxxx xxxx xxxx xxxx
+
+catexs03:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 3,3
+		Footprint: xxx xxx xxx
+
+catexs04:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 3,3
+		Footprint: xxx xxx xxx
+
+catexs05:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 3,3
+		Footprint: xxx xxx xxx
+
+catexs06:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 3,3
+		Footprint: xxx xxx xxx
+
+catexs07:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 3,3
+		Footprint: xxx xxx xxx
+
+catexs08:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 2,3
+		Footprint: xx xx xx
+
+capars01:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Eiffel Tower
+	Armor:
+		Type: steel
+	Health:
+		HP: 3000
+	Power:
+		Amount: -100
+	Building:
+		Dimensions: 4,4
+		Footprint: xxxx xxxx xxxx xxxx
+
+capars02:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 6,4
+		Footprint: xxxxxx xxxxxx xxxxxx xxxxxx
+
+capars04:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 500
+	Building:
+		Dimensions: 3,3
+		Footprint: xxx xxx xxx
+
+capars05:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 500
+	Building:
+		Dimensions: 3,3
+		Footprint: xxx xxx xxx
+
+capars06:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 500
+	Building:
+		Dimensions: 3,3
+		Footprint: xxx xxx xxx
+
+capars07:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Phone Booth
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 100
+	Building:
+		Dimensions: 1,1
+		Footprint: x
+
+capars08:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 6,4
+		Footprint: xxxxxx xxxxxx xxxxxx xxxxxx
+
+capars09:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 6,4
+		Footprint: xxxxxx xxxxxx xxxxxx xxxxxx
+
+capars10:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Bistro
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 4,3
+		Footprint: xxxx xxxx xxxx
+
+capars11:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Arc de Triumphe
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 3,4
+		Footprint: xxx xxx xxx xxx
+
+capars12:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Notre Dame
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 3,5
+		Footprint: xxx xxx xxx xxx xxx
+
+capars13:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Bistro
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 3,4
+		Footprint: xxx xxx xxx xxx
+
+capars14:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Bistro
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 4,3
+		Footprint: xxxx xxxx xxxx
+
+cafrma:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Farmhouse
+	RevealsShroud:
+		Range: 4c0
+	Health:
+		HP: 400
+	Building:
+		Dimensions: 2,2
+		Footprint: xx xx
+
+cafrmb:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Outhouse
+	RevealsShroud:
+		Range: 4c0
+	Health:
+		HP: 50
+	Building:
+		Dimensions: 1,1
+		Footprint: x
+
+caprs03:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Louvre
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 500
+	Building:
+		Dimensions: 6,4
+		Footprint: xxxxxx xxxxxx xxxxxx xxxxxx
+
+cagard01:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Guard Shack
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 100
+	Building:
+		Dimensions: 1,1
+		Footprint: x
+
+carus01:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Basil's Cathedral
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 4,4
+		Footprint: xxxx xxxx xxxx xxxx
+
+carus02g:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Kremlin Wall Clock Tower
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 1,1
+		Footprint: x
+
+carus03:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Kremlin Palace
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 2,5
+		Footprint: xx xx xx xx xx
+
+carus04:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 4,4
+		Footprint: xxxx xxxx xxxx xxxx
+
+carus05:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 4,4
+		Footprint: xxxx xxxx xxxx xxxx
+
+carus06:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 4,4
+		Footprint: xxxx xxxx xxxx xxxx
+
+carus08:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 1,1
+		Footprint: x
+
+carus09:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 2,1
+		Footprint: xx
+
+carus10:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 1,2
+		Footprint: x x
+
+carus11:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 2,1
+		Footprint: xx
+
+camiam01:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 4,2
+		Footprint: xxxx xxxx
+
+camiam02:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 4,2
+		Footprint: xxxx xxxx
+
+camiam03:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 2,3
+		Footprint: xx xx xx
+
+camiam04:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Lifeguard Hut
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 200
+	Building:
+		Dimensions: 1,1
+		Footprint: x
+
+camiam05:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 3,4
+		Footprint: xxx xxx xxx xxx
+
+camiam06:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 4,4
+		Footprint: xxxx xxxx xxxx xxxx
+
+camiam07:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 4,4
+		Footprint: xxxx xxxx xxxx xxxx
+
+
+camiam08:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Arizona Memorial
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 3,1
+		Footprint: xxx
+
+canwy05:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 4,4
+		Footprint: xxxx xxxx xxxx xxxx
+
+canwy09:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 400
+	Building:
+		Dimensions: 2,3
+		Footprint: xx xx xx
+
+canwy22:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 400
+	Building:
+		Dimensions: 3,3
+		Footprint: xxx xxx xxx
+
+canwy23:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 400
+	Building:
+		Dimensions: 3,2
+		Footprint: xxx xxx
+
+canwy24:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 400
+	Building:
+		Dimensions: 3,3
+		Footprint: xxx xxx xxx
+
+canwy25:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 400
+	Building:
+		Dimensions: 3,3
+		Footprint: xxx xxx xxx
+
+canwy26:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 400
+	Building:
+		Dimensions: 5,3
+		Footprint: xxxxx xxxxx xxxxx
+
+camex01:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Mayan Pyramid
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 12c0
+	Health:
+		HP: 2000
+	Building:
+		Dimensions: 3,2
+		Footprint: xxx xxx
+
+camex02:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Mayan Castillo
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 6,4
+		Footprint: xxxxxx xxxxxx xxxxxx xxxxxx
+
+camex03:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Mayan Minor Temple
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 3,3
+		Footprint: xxx xxx xxx
+
+camex04:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Mayan Large Temple
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 4,4
+		Footprint: xxxx xxxx xxxx xxxx
+
+camex05:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Mayan Platfrom
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 2,2
+		Footprint: xx xx
+
+caeur1:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Cottage
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 300
+	Building:
+		Dimensions: 2,2
+		Footprint: xx xx
+
+caeur2:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Cottage
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 300
+	Building:
+		Dimensions: 2,2
+		Footprint: xx xx
+
+caeur04:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 400
+	Building:
+		Dimensions: 4,3
+		Footprint: xxxx xxxx xxxx
+
+cachig01:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 3,2
+		Footprint: xxx xxx
+
+cachig02:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 2,3
+		Footprint: xx xx xx
+
+cachig03:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 3,2
+		Footprint: xxx xxx
+
+
+cachig04:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Associates Center
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 2,2
+		Footprint: xx xx
+
+cachig05:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Sears Tower
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 4,4
+		Footprint: xxxx xxxx xxxx xxxx
+
+cachig06:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Water Tower
+	Armor:
+		Type: steel
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 2,2
+		Footprint: xx xx
+
+castl01:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 4,4
+		Footprint: xxxx xxxx xxxx xxxx
+
+castl02:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 4,4
+		Footprint: xxxx xxxx xxxx xxxx
+
+castl03:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 4,4
+		Footprint: xxxx xxxx xxxx xxxx
+
+castl04:
+	Inherits: ^CivBuilding
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 2,6
+		Footprint: xx xx xx xx xx xx
+
+castl05a:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Busch Stadium
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 600
+	Building:
+		Dimensions: 4,4
+		Footprint: xxxx xxxx xxxx xxxx
+
+castl05b:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Busch Stadium
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 600
+	Building:
+		Dimensions: 4,4
+		Footprint: xxxx xxxx xxxx xxxx
+
+castl05c:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Busch Stadium
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 600
+	Building:
+		Dimensions: 4,4
+		Footprint: xxxx xxxx xxxx xxxx
+
+castl05d:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Busch Stadium
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 600
+	Building:
+		Dimensions: 4,4
+		Footprint: xxxx xxxx xxxx xxxx
+
+castl05e:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Busch Stadium
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 600
+	Building:
+		Dimensions: 4,4
+		Footprint: xxxx xxxx xxxx xxxx
+
+castl05f:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Busch StadiumF
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 600
+	Building:
+		Dimensions: 4,4
+		Footprint: xxxx xxxx xxxx xxxx
+
+castl05g:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Busch Stadium
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 600
+	Building:
+		Dimensions: 4,4
+		Footprint: xxxx xxxx xxxx xxxx
+
+castl05h:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Busch Stadium
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 600
+	Building:
+		Dimensions: 4,4
+		Footprint: xxxx xxxx xxxx xxxx
+
+camsc07:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Thatched Hut Chief
+	Armor:
+		Type: concrete
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 600
+	Building:
+		Dimensions: 2,2
+		Footprint: xx xx
+
+camsc08:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Thatched Hut
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 200
+	Building:
+		Dimensions: 1,1
+		Footprint: x
+
+camsc09:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Thatched Hut
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 200
+	Building:
+		Dimensions: 1,1
+		Footprint: x
+
+camsc10:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: McBurger Kong
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 1000
+	Building:
+		Dimensions: 4,4
+		Footprint: xxxx xxxx xxxx xxxx
+
+cabunk01:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Concrete Bunker
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 2000
+	Building:
+		Dimensions: 2,2
+		Footprint: xx xx
+
+cabunk02:
+	Inherits: ^CivBuilding
+	Tooltip:
+		Name: Concrete Bunker
+	Armor:
+		Type: steel
+	RevealsShroud:
+		Range: 6c0
+	Health:
+		HP: 2000
+	Building:
+		Dimensions: 2,2
+		Footprint: xx xx

--- a/rules/civilian-vehicles.yaml
+++ b/rules/civilian-vehicles.yaml
@@ -1,162 +1,93 @@
 bus:
-	Inherits: ^Vehicle
-	Valued:
-		Cost: 800
+	Inherits: ^CivVehicle
 	Tooltip:
 		Name: School Bus
-	Mobile:
-		ROT: 5
-		Speed: 113
-	Health:
-		HP: 100
-	Armor:
-		Type: Light
-	RevealsShroud:
-		Range: 5c0
 	Cargo:
 		Types: Infantry
 		MaxWeight: 20
 		PipCount: 5
 		UnloadVoice: Move
-	RenderSprites:
-	Selectable:
-		Bounds: 64, 52, 0, -6
-	RenderVoxels:
-	WithVoxelBody:
-	Voiced:
-		VoiceSet: CarVoice
+
+limo:
+	Inherits: ^CivVehicle
+	Tooltip:
+		Name: Presidential Limousine
+	Cargo:
+		Types: Infantry
+		MaxWeight: 20
+		PipCount: 5
+		UnloadVoice: Move
 
 pick:
-	Inherits: ^Vehicle
-	Valued:
-		Cost: 800
+	Inherits: ^CivVehicle
 	Tooltip:
 		Name: Pickup Truck
-	Mobile:
-		ROT: 5
-		Speed: 113
-	Health:
-		HP: 100
-	Armor:
-		Type: Light
-	RevealsShroud:
-		Range: 5c0
-	RenderSprites:
-	Selectable:
-		Bounds: 64, 52, 0, -6
-	RenderVoxels:
-	WithVoxelBody:
-	Voiced:
-		VoiceSet: CarVoice
 
 car:
-	Inherits: ^Vehicle
-	Valued:
-		Cost: 800
+	Inherits: ^CivVehicle
 	Tooltip:
 		Name: Automobile
-	Mobile:
-		ROT: 5
-		Speed: 113
-	Health:
-		HP: 100
-	Armor:
-		Type: Light
-	RevealsShroud:
-		Range: 5c0
-	RenderSprites:
-	Selectable:
-		Bounds: 64, 52, 0, -6
-	RenderVoxels:
-	WithVoxelBody:
-	Voiced:
-		VoiceSet: CarVoice
+
+wini:
+	Inherits: ^CivVehicle
+	Tooltip:
+		Name: Recreational Vehicle
+
+propa:
+	Inherits: ^CivVehicle
+	Tooltip:
+		Name: Propaganda Truck
 
 cop:
-	Inherits: ^Vehicle
-	Valued:
-		Cost: 800
+	Inherits: ^CivVehicle
 	Tooltip:
 		Name: Police Car
-	Mobile:
-		Speed: 113
-	Health:
-		HP: 100
-	Armor:
-		Type: Light
-	RevealsShroud:
-		Range: 5c0
-	RenderSprites:
-	Selectable:
-		Bounds: 64, 52, 0, -6
-	RenderVoxels:
-	WithVoxelBody:
-	Voiced:
-		VoiceSet: CarVoice
+
+euroc:
+	Inherits: ^CivVehicle
+	Tooltip:
+		Name: European Car
 
 cona:
-	Inherits: ^Vehicle
-	Valued:
-		Cost: 800
+	Inherits: ^CivVehicle
 	Tooltip:
 		Name: Excavator
-	Mobile:
-		Speed: 113
-	Health:
-		HP: 100
-	Armor:
-		Type: Light
-	RevealsShroud:
-		Range: 5c0
-	RenderSprites:
-	Selectable:
-		Bounds: 64, 52, 0, -6
 	RenderVoxels:
 		NormalsPalette: ts-normals
-	WithVoxelBody:
-	Voiced:
-		VoiceSet: CarVoice
 
 trucka:
-	Inherits: ^Vehicle
-	Valued:
-		Cost: 800
+	Inherits: ^CivVehicle
 	Tooltip:
 		Name: Truck
-	Mobile:
-		Speed: 113
-	Health:
-		HP: 100
-	Armor:
-		Type: Light
-	RevealsShroud:
-		Range: 5c0
-	RenderSprites:
-	Selectable:
-		Bounds: 64, 52, 0, -6
-	RenderVoxels:
-	WithVoxelBody:
-	Voiced:
-		VoiceSet: CarVoice
 
 truckb:
-	Inherits: ^Vehicle
-	Valued:
-		Cost: 800
+	Inherits: ^CivVehicle
 	Tooltip:
 		Name: Truck
-	Mobile:
-		Speed: 113
-	Health:
-		HP: 100
-	Armor:
-		Type: Light
-	RevealsShroud:
-		Range: 5c0
-	RenderSprites:
-	Selectable:
-		Bounds: 64, 52, 0, -6
-	RenderVoxels:
-	WithVoxelBody:
-	Voiced:
-		VoiceSet: CarVoice
+
+suvb:
+	Inherits: ^CivVehicle
+	Tooltip:
+		Name: Black SUV
+
+suvw:
+	Inherits: ^CivVehicle
+	Tooltip:
+		Name: White SUV
+
+stang:
+	Inherits: ^CivVehicle
+	Tooltip:
+		Name: Mustang
+		GenericName: Sports Car
+
+ptruck:
+	Inherits: ^CivVehicle
+	Tooltip:
+		Name: Pickup Truck
+
+taxi:
+	Inherits: ^CivVehicle
+	Tooltip:
+		Name: Taxi
+

--- a/rules/defaults.yaml
+++ b/rules/defaults.yaml
@@ -617,6 +617,34 @@
 	Armor:
 		Type: Wood
 
+^StreetSign:
+	Inherits: ^Tree
+	Tooltip:
+		Name: Street Sign
+
+^TrafficLight:
+	Inherits: ^Tree
+	Tooltip:
+		Name: Traffic Light
+
+^StreetLight:
+	Inherits: ^Tree
+	Tooltip:
+		Name: Street Light
+	Armor:
+		Type: steel
+	Health:
+		HP: 50
+
+^TelephonePole:
+	Inherits: ^Tree
+	Tooltip:
+		Name: Utility Pole
+	Health:
+		HP: 20
+	Armor:
+		Type: Concrete
+
 ^Rock:
 	Inherits@1: ^SpriteActor
 	WithSpriteBody:

--- a/rules/defaults.yaml
+++ b/rules/defaults.yaml
@@ -413,6 +413,26 @@
 		ChronoshiftSound: schrmov.wav
 		ReturnToOrigin: false
 
+^CivVehicle:
+	Inherits: ^Vehicle
+	Tooltip:
+		GenericName: Civilian Vehicle
+	Valued:
+		Cost: 800
+	Mobile:
+		Speed: 113
+	Health:
+		HP: 100
+	Armor:
+		Type: Light
+	RevealsShroud:
+		Range: 5c0
+	Selectable:
+		Bounds: 64, 52, 0, -6
+	WithVoxelBody:
+	Voiced:
+		VoiceSet: CarVoice
+
 ^Aircraft:
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^GainsExperience

--- a/rules/palettes.yaml
+++ b/rules/palettes.yaml
@@ -8,6 +8,21 @@
 		Tileset: TEMPERATE
 		Filename: unittem.pal
 		ShadowIndex: 1
+	PaletteFromFile@temperatecity:
+		Name: city
+		Tileset: TEMPERATE
+		Filename: citytem.pal
+		ShadowIndex: 1
+	PaletteFromFile@snowcity:
+		Name: city
+		Tileset: SNOW
+		Filename: citysno.pal
+		ShadowIndex: 1
+	PaletteFromFile@urbancity:
+		Name: city
+		Tileset: URBAN
+		Filename: cityurb.pal
+		ShadowIndex: 1
 	PaletteFromFile@playerurb:
 		Name: player
 		Tileset: URBAN

--- a/rules/tech-structures.yaml
+++ b/rules/tech-structures.yaml
@@ -39,3 +39,4 @@ cahosp:
 	RepairsUnits:
 		StartRepairingNotification:
 	RallyPoint:
+	WithIdleOverlay:

--- a/sequences/civilian-props.yaml
+++ b/sequences/civilian-props.yaml
@@ -1,0 +1,256 @@
+hdstn01:
+	Defaults:
+		UseTilesetExtension: true
+	idle:
+		ShadowStart: 1
+
+lt_gen01:
+	Defaults:
+		UseTilesetExtension: true
+	idle:
+		ShadowStart: 1
+
+lt_gen02:
+	Defaults:
+		UseTilesetExtension: true
+	idle:
+		ShadowStart: 1
+
+lt_gen03:
+	Defaults:
+		UseTilesetExtension: true
+	idle:
+		ShadowStart: 1
+
+lt_gen04:
+	Defaults:
+		UseTilesetExtension: true
+	idle:
+		ShadowStart: 1
+
+lt_sgn01:
+	Defaults:
+		UseTilesetExtension: true
+	idle:
+		ShadowStart: 1
+
+lt_sgn02:
+	Defaults:
+		UseTilesetExtension: true
+	idle:
+		ShadowStart: 1
+
+lt_sgn03:
+	Defaults:
+		UseTilesetExtension: true
+	idle:
+		ShadowStart: 1
+
+lt_sgn04:
+	Defaults:
+		UseTilesetExtension: true
+	idle:
+
+lt_eur01:
+	Defaults:
+		UseTilesetExtension: true
+	idle:
+		ShadowStart: 1
+
+lt_eur02:
+	Defaults:
+		UseTilesetExtension: true
+	idle:
+		ShadowStart: 1
+
+pole01:
+	Defaults:
+		UseTilesetExtension: true
+	idle:
+		ShadowStart: 1
+
+pole02:
+	Defaults:
+		UseTilesetExtension: true
+	idle:
+		ShadowStart: 1
+
+sign01:
+	Defaults:
+		UseTilesetExtension: true
+	idle:
+		ShadowStart: 1
+
+sign02:
+	Defaults:
+		UseTilesetExtension: true
+	idle:
+		ShadowStart: 1
+
+sign03:
+	Defaults:
+		UseTilesetExtension: true
+	idle:
+
+sign04:
+	Defaults:
+		UseTilesetExtension: true
+	idle:
+		ShadowStart: 1
+
+sign05:
+	Defaults:
+		UseTilesetExtension: true
+	idle:
+		ShadowStart: 1
+
+sign06:
+	Defaults:
+		UseTilesetExtension: true
+	idle:
+		ShadowStart: 1
+
+trff01:
+	Defaults:
+		UseTilesetExtension: true
+	idle:
+		ShadowStart: 1
+
+camsc01:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 3
+
+camsc02:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 3
+
+camsc03:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 3
+
+camsc04:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 3
+
+camsc05:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 3
+
+camsc06:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 3
+
+camsc11:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 3
+
+camsc12:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 3
+
+camsc13:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 3
+
+trff02:
+	Defaults:
+		UseTilesetExtension: true
+	idle:
+		ShadowStart: 1
+
+trff03:
+	Defaults:
+		UseTilesetExtension: true
+	idle:
+		ShadowStart: 1
+
+trff04:
+	Defaults:
+		UseTilesetExtension: true
+	idle:
+		ShadowStart: 1
+
+camisc01:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 3
+
+camisc02:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+
+camisc03:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 3
+
+camisc04:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 3
+
+camisc05:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 3
+
+camisc06:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 3
+
+caeuro05:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 3
+
+capark01:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 3
+
+capark02:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 3
+
+capark03:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 3
+
+ammo01:
+	idle:
+		ShadowStart: 3
+
+cabhut:
+	idle:
+		ShadowStart: 3

--- a/sequences/civilian-structures.yaml
+++ b/sequences/civilian-structures.yaml
@@ -109,11 +109,29 @@ cawash05:
 		ShadowStart: 5
 		Offset: -30, -45
 
+cawash06:
+	idle: cuwash06
+		ShadowStart: 5
+		Offset: -30, -45
+	damaged-idle: cuwash06
+		Start: 1
+		ShadowStart: 7
+		Offset: -30, -45
+
 cawash07:
 	idle: cuwash07
 		ShadowStart: 4
 		Offset: 0, -45
 	damaged-idle: cuwash07
+		Start: 1
+		ShadowStart: 5
+		Offset: 0, -45
+
+cawash08:
+	idle: cuwash08
+		ShadowStart: 4
+		Offset: 0, -45
+	damaged-idle: cuwash08
 		Start: 1
 		ShadowStart: 5
 		Offset: 0, -45
@@ -145,6 +163,15 @@ cawash11:
 		ShadowStart: 5
 		Offset: 0, -60
 
+cawsh12:
+	idle: cgwsh12
+		ShadowStart: 4
+		Offset: 0, -45
+	damaged-idle: cgwsh12
+		Start: 1
+		ShadowStart: 5
+		Offset: 0, -45
+
 cawash13:
 	idle: cuwash13
 		ShadowStart: 4
@@ -163,6 +190,48 @@ cawash14:
 		ShadowStart: 5
 		Offset: 0, -45
 
+cawash15:
+	idle: cgwash14
+		ShadowStart: 4
+		Offset: 0, -45
+	damaged-idle: cgwash14
+		Start: 1
+		ShadowStart: 5
+		Offset: 0, -45
+
+cawash16:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+cawash17:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+cawash18:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 3
+
+cawash19:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
 canewy01:
 	idle: cunewy01
 		ShadowStart: 4
@@ -172,14 +241,143 @@ canewy01:
 		ShadowStart: 5
 		Offset: 0, -60
 
-cawsh12:
-	idle: cgwsh12
+canewy04:
+	Defaults:
+	idle: cgnewy04
+	damaged-idle: cgnewy04
+		Start: 1
+
+canewy05:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 3
+
+canewy06:
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 4
-		Offset: 0, -45
-	damaged-idle: cgwsh12
+	damaged-idle:
 		Start: 1
 		ShadowStart: 5
-		Offset: 0, -45
+
+canewy07:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+canewy08:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+canewy10:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+canewy11:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+canewy12:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+canewy13:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+canewy14:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+canewy15:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+canewy16:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+canewy17:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+canewy18:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+canewy20:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+canewy21:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
 
 caarmy01:
 	Defaults:
@@ -191,6 +389,30 @@ caarmy01:
 		Start: 1
 		ShadowStart: 5
 		Offset: -15, -38
+
+caarmy02:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 2
+
+caarmy03:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 2
+
+caarmy04:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 2
 
 cawa2a:
 	Defaults:
@@ -257,6 +479,40 @@ cafarm02:
 		Start: 1
 		ShadowStart: 5
 		Offset: 0, -15
+
+cafarm06:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 2
+		ShadowStart: 5
+
+cafrma:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 2
+		ShadowStart: 5
+
+cafrmb:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 2
+
+cabarn02:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 2
 
 causfgl:
 	Defaults:
@@ -471,6 +727,50 @@ camisc06:
 		ShadowStart: 5
 		Offset: -15, -22
 
+camsc07:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+		Offset: -15, -22
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+		Offset: -15, -22
+
+camsc08:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+		Offset: -15, -22
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+		Offset: -15, -22
+
+camsc09:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+		Offset: -15, -22
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+		Offset: -15, -22
+
+camsc10:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+		Offset: -15, -22
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+		Offset: -15, -22
+
 camsc11:
 	Defaults:
 		UseTilesetCode: true
@@ -504,29 +804,252 @@ camsc13:
 		ShadowStart: 5
 		Offset: 15, -22
 
-calit01e:
-	idle: culit01e
-		ShadowStart: 0
-		Offset: 0, 0
-	damaged-idle: culit01e
-		ShadowStart: 1
-		Offset: 0, 0
+camiam01:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 2
+		ShadowStart: 5
 
-calit01w:
-	idle: culit01w
-		ShadowStart: 1
-		Offset: 0, 0
-	damaged-idle: culit01w
-		ShadowStart: 1
-		Offset: 0, 0
+camiam02:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 2
+		ShadowStart: 5
 
-capol01w:
-	idle: cupol01w
-		ShadowStart: 0
-		Offset: 0, 0
-	damaged-idle: cupol01w
-		ShadowStart: 0
-		Offset: 0, 0
+camiam03:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 2
+		ShadowStart: 5
+
+camiam04:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 2
+		ShadowStart: 5
+
+camiam05:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 2
+		ShadowStart: 5
+
+camiam06:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 2
+		ShadowStart: 5
+
+camiam07:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 2
+		ShadowStart: 5
+
+camiam08:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 2
+		ShadowStart: 5
+
+castrt01:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 3
+
+castrt02:
+	idle:
+		ShadowStart: 3
+
+castrt03:
+	idle:
+		ShadowStart: 3
+
+castrt04:
+	idle:
+		ShadowStart: 3
+
+castrt05:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 3
+
+camex01:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 2
+		ShadowStart: 5
+
+camex02:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 2
+		ShadowStart: 5
+
+camex03:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 2
+		ShadowStart: 5
+
+camex04:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 2
+		ShadowStart: 5
+
+camex05:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 2
+		ShadowStart: 5
+
+castl01:
+	Defaults:
+		UseTilesetCode: true
+	idle: custl01
+		ShadowStart: 4
+	damaged-idle: custl01
+		Start: 1
+		ShadowStart: 5
+
+castl02:
+	Defaults:
+		UseTilesetCode: true
+	idle: custl02
+		ShadowStart: 4
+	damaged-idle: custl02
+		Start: 1
+		ShadowStart: 5
+
+castl03:
+	Defaults:
+		UseTilesetCode: true
+	idle: custl03
+		ShadowStart: 4
+	damaged-idle: custl03
+		Start: 1
+		ShadowStart: 5
+
+castl04:
+	idle: cgstl04
+		ShadowStart: 3
+	damaged-idle: cgstl04
+		Start: 1
+		ShadowStart: 4
+
+castl05a:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+castl05b:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+castl05c:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+castl05d:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+castl05e:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+castl05f:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+castl05g:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+castl05h:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
 
 cacolo01:
 	Defaults:
@@ -572,11 +1095,668 @@ cagas01:
 		ShadowStart: 5
 		Offset: 0, -45
 
-catech01:
-	idle: cutech01
+cahse01:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 2
+	damaged-idle:
+		Start: 1
 		ShadowStart: 4
-		Offset: 0, -45
-	damaged-idle: cutech01
+
+cahse02:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 2
+	damaged-idle:
+		Start: 1
+		ShadowStart: 4
+
+cahse03:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 2
+	damaged-idle:
+		Start: 1
+		ShadowStart: 4
+
+cahse04:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 2
+	damaged-idle:
+		Start: 1
+		ShadowStart: 4
+
+cahse05:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+
+cahse06:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 2
+	damaged-idle:
+		Start: 1
+		ShadowStart: 4
+
+cahse07:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 2
+	damaged-idle:
+		Start: 1
+		ShadowStart: 4
+
+cawt01:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 2
+	damaged-idle:
+		Start: 1
+		ShadowStart: 3
+
+cabunk01:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
 		Start: 1
 		ShadowStart: 5
-		Offset: 0, -45
+
+cabunk02:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+carus01:
+	idle: cgrus01
+		ShadowStart: 4
+	damaged-idle: cgrus01
+		Start: 1
+		ShadowStart: 5
+
+carus02a:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+carus02b:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+carus02c:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+carus02d:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+carus02e:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+carus02f:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+carus02g:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+carus03:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+carus04:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+carus05:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+carus07:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+carus06:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+carus08:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+carus09:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+carus10:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+carus11:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+cachig01:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+cachig02:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+cachig03:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+cachig04:
+	idle: cgchig04
+		ShadowStart: 4
+	damaged-idle: cgchig04
+		Start: 1
+		ShadowStart: 5
+
+cachig05:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+cachig06:
+	idle: cgchig06
+		ShadowStart: 4
+	damaged-idle: cgchig06
+		Start: 1
+		ShadowStart: 5
+
+catexs01:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+catexs02:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+catexs03:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+catexs04:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+catexs05:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+catexs06:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+catexs07:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+catexs08:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+canwy05:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+canwy09:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+canwy22:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+canwy23:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+canwy24:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+canwy25:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+canwy26:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+camov01:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 3
+	damaged-idle:
+		Start: 1
+		ShadowStart: 4
+	idle-overlay: camov01_a
+		Length: 30
+		Tick: 200
+	damaged-idle-overlay: camov01_a
+		Start: 30
+		Length: 30
+		Tick: 200
+
+camov02:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+	idle-overlay: camov02_a
+		Length: 2
+		Tick: 200
+	damaged-idle-overlay: camov02_a
+		Start: 2
+		Length: 2
+		Tick: 200
+
+capars01:
+	idle: cgpars01
+		ShadowStart: 4
+	damaged-idle: cgpars01
+		Start: 1
+		ShadowStart: 5
+
+capars02:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+capars04:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+capars05:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+capars06:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+capars07:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+capars08:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+capars09:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+capars10:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+capars11:
+	idle: cgpars11
+		ShadowStart: 4
+	damaged-idle: cgpars11
+		Start: 1
+		ShadowStart: 5
+
+capars12:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+capars13:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+capars14:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+cats01:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 3
+	damaged-idle:
+		Start: 1
+		ShadowStart: 4
+
+cagard01:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 3
+	damaged-idle:
+		Start: 1
+		ShadowStart: 4
+
+caeur1:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+caeur2:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+caeur04:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+caprs03:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+caswst01:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+
+cacity01:
+	idle:
+		ShadowStart: 3
+
+cacity02:
+	idle:
+		ShadowStart: 3
+
+cacity03:
+	idle:
+		ShadowStart: 3
+
+cacity04:
+	idle:
+		ShadowStart: 3
+
+city01:
+	idle:
+		ShadowStart: 2
+
+city02:
+	idle:
+		ShadowStart: 2
+
+city03:
+	idle:
+		ShadowStart: 2
+
+city04:
+	idle:
+		ShadowStart: 2
+
+city05:
+	idle:
+		ShadowStart: 2

--- a/sequences/civilian-structures.yaml
+++ b/sequences/civilian-structures.yaml
@@ -182,112 +182,132 @@ cawsh12:
 		Offset: 0, -45
 
 caarmy01:
-	idle: cuarmy01
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 4
 		Offset: -15, -38
-	damaged-idle: cuarmy01
+	damaged-idle:
 		Start: 1
 		ShadowStart: 5
 		Offset: -15, -38
 
 cawa2a:
-	idle: cuwa2a
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 4
 		Offset: 0, -45
-	damaged-idle: cuwa2a
+	damaged-idle:
 		Start: 1
 		ShadowStart: 5
 		Offset: 0, -45
 
 cawa2b:
-	idle: cuwa2b
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 4
 		Offset: 0, -45
-	damaged-idle: cuwa2b
+	damaged-idle:
 		Start: 1
 		ShadowStart: 5
 		Offset: 0, -45
 
 cawa2c:
-	idle: cuwa2c
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 4
 		Offset: 0, -45
-	damaged-idle: cuwa2c
+	damaged-idle:
 		Start: 1
 		ShadowStart: 5
 		Offset: 0, -45
 
 cawa2d:
-	idle: cuwa2d
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 4
 		Offset: 0, -45
-	damaged-idle: cuwa2d
+	damaged-idle:
 		Start: 1
 		ShadowStart: 5
 		Offset: 0, -45
 
 cafarm01:
-	idle: cufarm01
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 4
 		Offset: 0, -30
-	damaged-idle: cufarm01
+	damaged-idle:
 		Start: 1
 		ShadowStart: 5
 		Offset: 0, -30
 
 cafarm02:
-	idle: cufarm02
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 4
 		Offset: 0, -16
-	damaged-idle: cufarm02
+	damaged-idle:
 		Start: 1
 		ShadowStart: 5
 		Offset: 0, -15
 
 causfgl:
-	idle: cuusfgl
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 4
 		Offset: 0, -15
-	damaged-idle: cuusfgl
+	damaged-idle:
 		Start: 1
 		ShadowStart: 5
 		Offset: 0, -15
-	flag: cuusfgl_a
+	flag: causfgl_a
 		Length: 16
 		ShadowStart: 16
 		Offset: 0, -15
 
 carufgl:
-	idle: curufgl
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 4
 		Offset: 0, -15
-	damaged-idle: curufgl
+	damaged-idle:
 		Start: 1
 		ShadowStart: 5
 		Offset: 0, -15
-	flag: curufgl_a
+	flag: carufgl_a
 		Length: 16
 		ShadowStart: 16
 		Offset: 0, -15
 
 cairfgl:
-	idle: cuirfgl
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 4
 		Offset: 0, -15
-	damaged-idle: cuirfgl
+	damaged-idle:
 		Start: 1
 		ShadowStart: 5
 		Offset: 0, -15
-	flag: cuirfgl_a
+	flag: cairfgl_a
 		Length: 16
 		ShadowStart: 16
 		Offset: 0, -15
 
 capofgl:
-	idle: cuusfgl # Polish flag is only in isosnow.mix
+	idle: capofgl
 		ShadowStart: 4
 		Offset: 0, -15
-	damaged-idle: cuusfgl
+	damaged-idle: capofgl
 		Start: 1
 		ShadowStart: 5
 		Offset: 0, -15
@@ -297,10 +317,12 @@ capofgl:
 		Offset: 0, -15
 
 caskfgl:
-	idle: cuskfgl
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 4
 		Offset: 0, -15
-	damaged-idle: cuskfgl
+	damaged-idle:
 		Start: 1
 		ShadowStart: 5
 		Offset: 0, -15
@@ -310,10 +332,12 @@ caskfgl:
 		Offset: 0, -15
 
 calbfgl:
-	idle: culbfgl
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 4
 		Offset: 0, -15
-	damaged-idle: culbfgl
+	damaged-idle:
 		Start: 1
 		ShadowStart: 5
 		Offset: 0, -15
@@ -323,10 +347,12 @@ calbfgl:
 		Offset: 0, -15
 
 cafrfgl:
-	idle: cufrfgl
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 4
 		Offset: 0, -15
-	damaged-idle: cufrfgl
+	damaged-idle:
 		Start: 1
 		ShadowStart: 5
 		Offset: 0, -15
@@ -336,10 +362,12 @@ cafrfgl:
 		Offset: 0, -15
 
 cagefgl:
-	idle: cugefgl
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 4
 		Offset: 0, -15
-	damaged-idle: cugefgl
+	damaged-idle:
 		Start: 1
 		ShadowStart: 5
 		Offset: 0, -15
@@ -349,10 +377,12 @@ cagefgl:
 		Offset: 0, -15
 
 cacufgl:
-	idle: cucufgl
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 4
 		Offset: 0, -15
-	damaged-idle: cucufgl
+	damaged-idle:
 		Start: 1
 		ShadowStart: 5
 		Offset: 0, -15
@@ -362,10 +392,12 @@ cacufgl:
 		Offset: 0, -15
 
 caukfgl:
-	idle: cuukfgl
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 4
 		Offset: 0, -15
-	damaged-idle: cuukfgl
+	damaged-idle:
 		Start: 1
 		ShadowStart: 5
 		Offset: 0, -15
@@ -375,81 +407,99 @@ caukfgl:
 		Offset: 0, -15
 
 camisc01:
-	idle: cumisc01
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 4
 		Offset: 0, -15
-	damaged-idle: cumisc01
+	damaged-idle:
 		ShadowStart: 4
 		Offset: 0, -15
 
 camisc02:
-	idle: cumisc02
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 4
 		Offset: 0, -15
-	damaged-idle: cumisc02
+	damaged-idle:
 		Start: 1
 		ShadowStart: 5
 		Offset: 0, -15
 
 camisc03:
-	idle: cumisc03
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 4
 		Offset: 0, -15
-	damaged-idle: cumisc03
+	damaged-idle:
 		Start: 1
 		ShadowStart: 5
 		Offset: 0, -15
 
 camisc04:
-	idle: cumisc04
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 4
 		Offset: 0, -15
-	damaged-idle: cumisc04
+	damaged-idle:
 		Start: 1
 		ShadowStart: 5
 		Offset: 0, -15
 
 camisc05:
-	idle: cumisc05
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 2
 		Offset: 0, -15
-	damaged-idle: cumisc05
+	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 		Offset: 0, -15
 
 camisc06:
-	idle: cumisc06
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 4
 		Offset: -15, -22
-	damaged-idle: cumisc06
+	damaged-idle:
 		Start: 1
 		ShadowStart: 5
 		Offset: -15, -22
 
 camsc11:
-	idle: cumsc11
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 4
 		Offset: 0, -15
-	damaged-idle: cumsc11
+	damaged-idle:
 		Start: 1
 		ShadowStart: 5
 		Offset: 0, -15
 
 camsc12:
-	idle: cumsc12
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 4
 		Offset: 0, -15
-	damaged-idle: cumsc12
+	damaged-idle:
 		Start: 1
 		ShadowStart: 5
 		Offset: 0, -15
 
 camsc13:
-	idle: cumsc13
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 4
 		Offset: 15, -22
-	damaged-idle: cumsc13
+	damaged-idle:
 		Start: 1
 		ShadowStart: 5
 		Offset: 15, -22
@@ -479,37 +529,45 @@ capol01w:
 		Offset: 0, 0
 
 cacolo01:
-	idle: cucolo01
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 4
 		Offset: -15, -53
-	damaged-idle: cucolo01
+	damaged-idle:
 		Start: 1
 		ShadowStart: 5
 		Offset: -15, -53
 
 caind01:
-	idle: cuind01
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 4
 		Offset: 0, -53
-	damaged-idle: cuind01
+	damaged-idle:
 		Start: 1
 		ShadowStart: 5
 		Offset: 0, -53
 
 calab:
-	idle: culab
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 4
 		Offset: 15, -45
-	damaged-idle: culab
+	damaged-idle:
 		Start: 1
 		ShadowStart: 5
 		Offset: 15, -45
 
 cagas01:
-	idle: cugas01
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 4
 		Offset: 0, -45
-	damaged-idle: cugas01
+	damaged-idle:
 		Start: 1
 		ShadowStart: 5
 		Offset: 0, -45

--- a/sequences/soviet-structures.yaml
+++ b/sequences/soviet-structures.yaml
@@ -303,7 +303,7 @@ nadept:
 		Length: 10
 		ShadowStart: 20
 		Tick: 180
-	damaged-idle: ngdept_d
+	damaged-idle: ngdept_b
 		Start: 10
 		Length: 10
 		ShadowStart: 29

--- a/sequences/soviet-structures.yaml
+++ b/sequences/soviet-structures.yaml
@@ -462,25 +462,25 @@ napsis:
 		UseTilesetCode: false
 
 namisl:
+	Defaults:
+		Offset: 0, -42
 	idle: ngmisl_e
 		ShadowStart: 2
-		Offset: 0, -42
 	damaged-idle: ngmisl_e
 		Start: 1
 		ShadowStart: 3
-		Offset: 0, -42
 	critical-idle: ngmisl_e
 		Start: 1
 		ShadowStart: 3
-		Offset: 0, -42
 	make: ntmislmk
+		UseTilesetCode: true
 		Length: 26
 		ShadowStart: 26
 		TilesetOverrides:
 			TEMPERATE: TEMPERATE
 			URBAN: URBAN
-		Offset: 0, -42
 	icon: msslicon
+		Offset: 0,0
 
 nairon:
 	Defaults:

--- a/sequences/tech-structures.yaml
+++ b/sequences/tech-structures.yaml
@@ -1,26 +1,30 @@
 caoild:
-	idle: cuoild
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 4
 		Offset: 0, -30
-	damaged-idle: cuoild
+	damaged-idle:
 		Start: 1
 		ShadowStart: 5
 		Offset: 0, -30
-	idle-pump: cuoild_a
+	idle-pump: caoild_a
 		Length: 32
 		ShadowStart: 64
 		Offset: 0, -30
-	damaged-idle-pump: cuoild_a
+	damaged-idle-pump: caoild_a
 		Start: 32
 		Length: 32
 		ShadowStart: 96
 		Offset: 0, -30
 
 cahosp:
-	idle: cuhosp
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 4
 		Offset: -30, -75
-	damaged-idle: cuhosp
+	damaged-idle:
 		Start: 1
 		ShadowStart: 5
 		Offset: -30, -75

--- a/sequences/tech-structures.yaml
+++ b/sequences/tech-structures.yaml
@@ -28,6 +28,15 @@ cahosp:
 		Start: 1
 		ShadowStart: 5
 		Offset: -30, -75
+	idle-overlay: cahosp_a
+		Length: 2
+		Offset: -30, -75
+		Tick: 400
+	damaged-idle-overlay: cahosp_a
+		Start: 2
+		Length: 2
+		Offset: -30, -75
+		Tick: 400
 
 caoutp:
 	icon: xxicon

--- a/sequences/voxels.yaml
+++ b/sequences/voxels.yaml
@@ -173,7 +173,7 @@ subt: #Sub Torpedo needs voxel projectiles
 suvb:
 	idle:
 
-suvbw:
+suvw:
 	idle:
 
 taxi:


### PR DESCRIPTION
Closes https://github.com/OpenRA/ra2/issues/48.

The rules https://github.com/OpenRA/OpenRA/pull/10714 and sequences https://github.com/OpenRA/OpenRA/pull/10715 were automatically converted and then manually cleaned to use inheritance.

I noticed a lot of wrongdoings in our current rule setup. Many were hard-coding one sprite variant which doesn't come with snow in the arctic tileset. Should be all fixed now. Also got rid of the crash when the repair crane gets damaged already detected by https://github.com/OpenRA/ra2/pull/108.