### PR TITLE
Make the tesla coil use WithChargeOverlay instead of WithChargeAnimation

### DIFF
--- a/rules/soviet-structures.yaml
+++ b/rules/soviet-structures.yaml
@@ -681,7 +681,7 @@ tesla:
 		Bounds: 44, 88, -2, -33
 	Targetable:
 		TargetTypes: Ground, C4, DetonateAttack, Structure, TeslaBoost
-	WithChargeAnimation:
+	WithChargeOverlay:
 	Armament@primary:
 		Weapon: CoilBolt
 		LocalOffset: 0,0,2200

--- a/sequences/soviet-structures.yaml
+++ b/sequences/soviet-structures.yaml
@@ -579,11 +579,13 @@ tesla:
 		Length: 10
 		ShadowStart: 20
 		Tick: 100
+		ZOffset: 10
 	damaged-active: ngtsla_b
 		Start: 10
 		ShadowStart: 20
 		Length: 10
 		Tick: 100
+		ZOffset: 10
 	dead: ngtsladm # SHP broken & unused
 		Length: 20
 		ShadowStart: 20


### PR DESCRIPTION
also increase the ZOffset so that you can actually see the charging.
Fixes the charging being invisible and hiding the "main shadow".

![teslafire](https://cloud.githubusercontent.com/assets/7704140/12983509/d31aa91c-d0e9-11e5-8fb9-a5010f4b1750.gif)

Followup of #126.