### PR TITLE
Use the shared metrics of the common mod

### DIFF
--- a/metrics.yaml
+++ b/metrics.yaml
@@ -30,5 +30,4 @@ Metrics:
 	FactionSuffix-iraq: soviets
 	FactionSuffix-russia: soviets
 	IncompatibleVersionColor: D3D3D3
-	CantJoinGameColor: D3D3D3
 	IncompatibleProtectedGameColor: B22222

--- a/metrics.yaml
+++ b/metrics.yaml
@@ -20,10 +20,6 @@ Metrics:
 	TextContrastColor: 000000
 	ColorPickerRemapIndices: 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
 	ColorPickerActorType: ^amcv.colorpicker
-	SpawnFont: TinyBold
-	SpawnColor: FFFFFF
-	SpawnContrastColor: 000000
-	SpawnLabelOffset: 0,1
 	FactionSuffix-america: allies
 	FactionSuffix-korea: allies
 	FactionSuffix-france: allies
@@ -34,17 +30,5 @@ Metrics:
 	FactionSuffix-iraq: soviets
 	FactionSuffix-russia: soviets
 	IncompatibleVersionColor: D3D3D3
-	IncompatibleGameColor: A9A9A9
 	CantJoinGameColor: D3D3D3
-	ProtectedGameColor: FF0000
 	IncompatibleProtectedGameColor: B22222
-	WaitingGameColor: 00FF00
-	IncompatibleWaitingGameColor: 32CD32
-	GameStartedColor: FFA500
-	IncompatibleGameStartedColor: D2691E
-	GlobalChatTextColor: FFFFFF
-	GlobalChatNotificationColor: D3D3D3
-	PlayerStanceColorSelf: 32CD32
-	PlayerStanceColorAllies: FFFF00
-	PlayerStanceColorEnemies: FF0000
-	PlayerStanceColorNeutrals: D2B48C

--- a/mod.yaml
+++ b/mod.yaml
@@ -202,6 +202,7 @@ LobbyDefaults:
 	TechLevel: Unrestricted
 
 ChromeMetrics:
+	common|metrics.yaml
 	ra2|metrics.yaml
 
 Fonts:


### PR DESCRIPTION
Makes use of https://github.com/OpenRA/OpenRA/pull/10653 as requested in https://github.com/OpenRA/ra2/pull/128#discussion_r52912521.

Also removes a "CantJoinGameColor" entry. I have no idea where it came from and what it is/was used for.