### PR TITLE
Fix make dependencies missing Eluant.dll

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -106,6 +106,15 @@ elseif ($command -eq "dependencies")
 			cp mods/ts/OpenRA.Mods.TS.dll $targetDir
 		}
 
+		if (!(Test-Path Eluant.dll))
+		{
+			echo "Unable to find the Eluant dll!"
+		}
+		else
+		{
+			cp Eluant.dll $targetDir
+		}
+
 		cd $targetDir
 		cd ../..
 		echo "Dependencies copied."


### PR DESCRIPTION
`Eluant.dll` was added as dependency in #156.