### PR TITLE
Added GI sandbag deployment

### DIFF
--- a/rules/allied-infantry.yaml
+++ b/rules/allied-infantry.yaml
@@ -98,6 +98,10 @@ e1:
 		HP: 125
 	Mobile:
 		Speed: 31
+	SpeedMultiplier@immobile:
+		Modifier: 0
+		UpgradeTypes: deployed
+		UpgradeMinEnabledLevel: 1
 	Passenger:
 		PipType: Green
 		GrantUpgrades: ifv-machinegun
@@ -114,21 +118,33 @@ e1:
 		Weapon: M60E
 		UpgradeTypes: eliteweapon
 		UpgradeMinEnabledLevel: 1
-#	Armament@deployed:
-#		Weapon: para
-#		UpgradeTypes: deployed
-#		UpgradeMinEnabledLevel: 1
-#	Armament@elite-deployed:
-#		Weapon: paraE
-#		UpgradeTypes: eliteparaweapon
-#		UpgradeMinEnabledLevel: 1
+	Armament@deployed:
+		Weapon: para
+		UpgradeTypes: deployed
+		UpgradeMinEnabledLevel: 1
+	Armament@elite-deployed:
+		Weapon: paraE
+		UpgradeTypes: deployed, eliteweapon
+		UpgradeMinEnabledLevel: 2
 	WithInfantryBody:
+		UpgradeTypes: undeployed
+		UpgradeMinEnabledLevel: 1
 	Voiced:
 		VoiceSet: GIVoice
 	ProducibleWithLevel:
 		Prerequisites: barracks.infiltrated
 	QuantizeFacingsFromSequence:
 		Sequence: stand
+	DeployToUpgrade:
+		DeployedUpgrades: deployed
+		UndeployedUpgrades: undeployed
+		DeployAnimation: deploy
+		DeploySound: igidepa.wav
+		UndeploySound: igidepb.wav
+	WithFacingSpriteBody@deployed:
+		Sequence: deployed
+		UpgradeTypes: undeployed
+		UpgradeMaxEnabledLevel: 0
 
 snipe:
 	Inherits: ^Infantry


### PR DESCRIPTION
There is a huge limitation in the current upgrade / frontal attack code. The deployed GI can shoot at the exact same cell he shot with his normal rifle prior to deploying.