### PR TITLE
Added a BountySource badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 [![Build Status](https://travis-ci.org/OpenRA/ra2.svg?branch=master)](https://travis-ci.org/OpenRA/ra2)
 
 Consult the [wiki](https://github.com/OpenRA/ra2/wiki) for instructions on how to install and use this.
+
+[![Bountysource](https://api.bountysource.com/badge/tracker?tracker_id=27677844)](https://www.bountysource.com/teams/openra/issues?tracker_ids=27677844)


### PR DESCRIPTION
While @BountySource GitHub integration is a bit lacking https://github.com/bountysource/core/issues/1009, https://github.com/bountysource/core/issues/1010 and https://github.com/bountysource/core/issues/1011 have a badge in the mean time.