### PR TITLE
Remove the diplomacy menu button

### DIFF
--- a/chrome/ingame-player.yaml
+++ b/chrome/ingame-player.yaml
@@ -40,20 +40,6 @@ Container@PLAYER_WIDGETS:
 					X: 0
 					Y: 0
 					Children:
-						MenuButton@DIPLOMACY_BUTTON:
-							Logic: AddFactionSuffixLogic
-							MenuContainer: INGAME_DIPLOMACY_BG
-							HideIngameUI: false
-							Pause: false
-							Key: P
-							X: 16
-							Y: 21
-							Width: 69
-							Height: 23
-							Background: diplomacy-button
-							TooltipText: Diplomacy
-							TooltipContainer: TOOLTIP_CONTAINER
-							VisualHeight: 0
 						MenuButton@DEBUG_BUTTON:
 							Logic: AddFactionSuffixLogic
 							Key: escape Shift


### PR DESCRIPTION
Fixes #194.

I kept the `diplomacy-button-<faction>` definitions in `chrome.yaml` as those
buttons still exist in `chrome.png` anyway.