### PR TITLE
Fix the ingame infostats lacking an OBJECTIVE container

### DIFF
--- a/chrome/ingame-infostats.yaml
+++ b/chrome/ingame-infostats.yaml
@@ -3,28 +3,31 @@ Container@SKIRMISH_STATS:
 	Width: PARENT_RIGHT
 	Logic: GameInfoStatsLogic
 	Children:
-		Label@MISSION:
-			X: 20
-			Y: 20
-			Width: 482
-			Height: 25
-			Font: MediumBold
-			Text: Mission:
-		Label@STATS_STATUS:
-			X: 100
-			Y: 20
-			Width: PARENT_RIGHT - 10
-			Height: 25
-			Font: MediumBold
-		Checkbox@STATS_CHECKBOX:
-			X: 20
-			Y: 55
-			Width: 482
-			Height: 20
-			Font: Bold
-			Text: Destroy all opposition!
-			Disabled: true
-			TextColorDisabled: FFFFFF
+		Container@OBJECTIVE:
+			Height: 75
+			Children:
+				Label@MISSION:
+					X: 20
+					Y: 20
+					Width: 482
+					Height: 25
+					Font: MediumBold
+					Text: Mission:
+				Label@STATS_STATUS:
+					X: 100
+					Y: 20
+					Width: PARENT_RIGHT - 10
+					Height: 25
+					Font: MediumBold
+				Checkbox@STATS_CHECKBOX:
+					X: 20
+					Y: 55
+					Width: 482
+					Height: 20
+					Font: Bold
+					Text: Destroy all opposition!
+					Disabled: true
+					TextColorDisabled: FFFFFF
 		Container@STATS_HEADERS:
 			X: 22
 			Y: 80


### PR DESCRIPTION
Fixes #193.
See also https://github.com/OpenRA/OpenRA/commit/10738b0c7715766f1dd7cc251845e532c99f458d.

You can easily reproduce this by opening the menu as spectator.