### PR TITLE
Add a placeholder for the arrow sequence of beacon

### DIFF
--- a/rules/soviet-structures.yaml
+++ b/rules/soviet-structures.yaml
@@ -660,6 +660,7 @@ namisl:
 		CameraActor: camera
 		CameraRemoveDelay: 70
 		FlashType: Nuke
+		CircleSequence:
 
 nawall:
 	Inherits: ^Wall

--- a/sequences/misc.yaml
+++ b/sequences/misc.yaml
@@ -51,6 +51,9 @@ beacon:
 		Length: 20
 		Tick: 200
 		ZOffset: 2047
+	arrow: pbeacon
+		Length: 1
+		ZOffset: 2047
 
 crate-effects: #Temp Null Some SHPs cannot be read by openra at this time, expect more
 	Defaults: null


### PR DESCRIPTION
Fixes #197.

We could also just disable the beacon, but I think it would be better to have it and maybe get some artwork for a `beaconposter` like those we have in ra.

I'm going to file an upstream fix to allow "empty" arrow and circles sequences later today
(done: OpenRA/OpenRA#11216).