### PR TITLE
Update ChronoResourceDelivery namespaces.

### DIFF
--- a/OpenRA.Mods.RA2/Activities/ChronoResourceTeleport.cs
+++ b/OpenRA.Mods.RA2/Activities/ChronoResourceTeleport.cs
@@ -10,7 +10,7 @@
 #endregion
 
 using OpenRA.Activities;
-using OpenRA.Effects;
+using OpenRA.Mods.Common.Effects;
 using OpenRA.Mods.RA2.Traits;
 using OpenRA.Traits;
 


### PR DESCRIPTION
In accordance of SpriteEffect shifted from OpenRA.Effects to OpenRA.Mods.Common.Effects in upstream.

Fixes #217.