### PR TITLE
Fixed all dependencies being copied in the ra2 mod folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ script:
  - ln -sf ~/build/OpenRA/mods/ra/OpenRA.Mods.RA.dll ~/.openra/mods/ra2/OpenRA.Mods.RA2/dependencies
  - ln -sf ~/build/OpenRA/mods/ts/OpenRA.Mods.TS.dll ~/.openra/mods/ra2/OpenRA.Mods.RA2/dependencies
  - ln -sf ~/build/OpenRA/thirdparty/download/Eluant.dll ~/.openra/mods/ra2/OpenRA.Mods.RA2/dependencies
- - pushd ~/.openra/mods/ra2/OpenRA.Mods.RA2 && xbuild && popd
+ - pushd ~/.openra/mods/ra2/OpenRA.Mods.RA2 && xbuild && cp bin/Debug/OpenRA.Mods.RA2.dll .. && popd
  - travis_retry ~/.openra/mods/ra2/fetch-content.sh
  - mono --debug OpenRA.Utility.exe ra2 --check-yaml
  - mono --debug OpenRA.Utility.exe ra2 --check-sequence-sprites

--- a/OpenRA.Mods.RA2/OpenRA.Mods.RA2.csproj
+++ b/OpenRA.Mods.RA2/OpenRA.Mods.RA2.csproj
@@ -8,7 +8,6 @@
     <RootNamespace>OpenRA.Mods.RA2</RootNamespace>
     <AssemblyName>OpenRA.Mods.RA2</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <OutputPath>..</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Platform)' == 'AnyCPU' ">
     <PlatformTarget>x86</PlatformTarget>
@@ -19,6 +18,13 @@
     <Optimize>False</Optimize>
     <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <OutputPath>bin\Debug\</OutputPath>
+    <CustomCommands>
+      <CustomCommands>
+        <Command type="AfterBuild" command="cp ${TargetFile} .." workingdir="${ProjectDir}" />
+        <Command type="AfterBuild" command="cp ${TargetFile}.mdb .." workingdir="${ProjectDir}" />
+      </CustomCommands>
+    </CustomCommands>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DebugSymbols>False</DebugSymbols>
@@ -26,6 +32,13 @@
     <Optimize>True</Optimize>
     <CheckForOverflowUnderflow>False</CheckForOverflowUnderflow>
     <DefineConstants>TRACE</DefineConstants>
+    <OutputPath>bin\Release\</OutputPath>
+    <CustomCommands>
+      <CustomCommands>
+        <Command type="AfterBuild" command="cp ${TargetFile} .." workingdir="${ProjectDir}" />
+        <Command type="AfterBuild" command="cp ${TargetFile}.mdb .." workingdir="${ProjectDir}" />
+      </CustomCommands>
+    </CustomCommands>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
This might fix the `TypeLoadExceptions` haunting me in https://github.com/OpenRA/ra2/issues/208.