### PR TITLE
Remove LobbyDefaults from mod.yaml

### DIFF
--- a/mod.yaml
+++ b/mod.yaml
@@ -187,16 +187,6 @@ ServerTraits:
 	PlayerPinger
 	MasterServerPinger
 
-LobbyDefaults:
-	AllowCheats: true
-	Crates: true
-	StartingUnitsClass: none
-	FragileAlliances: false
-	Shroud: true
-	Fog: true
-	ShortGame: false
-	TechLevel: Unrestricted
-
 ChromeMetrics:
 	common|metrics.yaml
 	ra2|metrics.yaml

--- a/rules/player.yaml
+++ b/rules/player.yaml
@@ -46,6 +46,7 @@ Player:
 	PlayerResources:
 	ActorGroupProxy:
 	DeveloperMode:
+		Enabled: true
 	GpsWatcher:
 	Shroud:
 	FrozenActorLayer:


### PR DESCRIPTION
Fixes #241.

`LobbyDefaults` were removed as part of https://github.com/OpenRA/OpenRA/pull/10839.