### PR TITLE
Removed ReturnFire stance from snipers

### DIFF
--- a/rules/allied-infantry.yaml
+++ b/rules/allied-infantry.yaml
@@ -154,8 +154,6 @@ snipe:
 		Range: 8c0
 	Armor:
 		Type: None
-	AutoTarget:
-		InitialStance: ReturnFire
 	Armament@primary:
 		Weapon: awp
 	AttackFrontal:


### PR DESCRIPTION
This was probably copied from the cloaked RA mod sniper. Closes https://github.com/OpenRA/ra2/issues/263.