### PR TITLE
Implement Cake-based build system

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,6 @@
 
 Consult the [wiki](https://github.com/OpenRA/ra2/wiki) for instructions on how to install and use this.
 
+You must have [`cake`](http://cakebuild.net/) installed if you want to build this via the makefiles provided (`make.ps1`, `makefile`).
+
 [![Bountysource](https://api.bountysource.com/badge/tracker?tracker_id=27677844)](https://www.bountysource.com/teams/openra/issues?tracker_ids=27677844)

--- a/build.cake
+++ b/build.cake
@@ -1,0 +1,112 @@
+// OS X: brew install cake
+// Windows: choco install cake.portable
+//
+// Example:
+// cake -auto=true -openra-root=~/projects/openra
+
+var target = Argument("target", "default").ToLowerInvariant();
+var configuration = Argument("configuration", "Debug");
+
+var rootDir = Directory(".");
+var depsDir = Directory("./OpenRA.Mods.RA2/dependencies");
+
+// TODO: Combine 'deps' and 'depsInOpenRA' into an array of pairs/structs
+var deps = new[] {
+    "Eluant.dll",
+    "OpenRA.Game.exe",
+    "OpenRA.Mods.Common.dll",
+    "OpenRA.Mods.RA.dll",
+    "OpenRA.Mods.TS.dll"
+};
+
+var depsInOpenRA = new[] {
+    "Eluant.dll",
+    "OpenRA.Game.exe",
+    "mods/common/OpenRA.Mods.Common.dll",
+    "mods/ra/OpenRA.Mods.RA.dll",
+    "mods/ts/OpenRA.Mods.TS.dll"
+};
+
+// Location on-disk of the OpenRA source code.
+var openraRoot = Argument<string>("openra-root", null);
+
+// Should dependencies be automatically copied (if found in openraRoot)?
+var auto = Argument<bool>("auto", false);
+
+Task("deps").Does(() => {
+    var missingDeps = new List<string>();
+    foreach (var dep in deps)
+    {
+        var fullPath = System.IO.Path.Combine(depsDir.Path.FullPath, dep);
+        if (!System.IO.File.Exists(fullPath))
+            missingDeps.Add(dep);
+    }
+
+    if (!missingDeps.Any())
+    {
+        Information("All dependencies accounted for. Aborting 'deps' task.");
+        return;
+    }
+
+    // Steps to resolving dependency location:
+    //   1) environment variable OPENRA_ROOT
+    //   2) -openra-root=<path> command-line argument
+    //   3) Ask the user for the path (only if `auto` is false!)
+
+    if (string.IsNullOrWhiteSpace(openraRoot))
+        openraRoot = Environment.GetEnvironmentVariable("OPENRA_ROOT");
+
+    if (!auto && string.IsNullOrWhiteSpace(openraRoot))
+    {
+        Console.Write("Please enter the path to the OpenRA root: ");
+        openraRoot = Console.ReadLine();
+    }
+
+    if (openraRoot.StartsWith("~"))
+        openraRoot = openraRoot.Replace("~", IsRunningOnWindows() ?
+            Environment.ExpandEnvironmentVariables("%HOMEDRIVE%%HOMEPATH%") :
+            Environment.GetEnvironmentVariable("HOME"));
+
+    var missingDepsCopy = missingDeps.ToArray();
+    for (var i = 0; i < missingDepsCopy.Length; i++)
+    {
+        var dep = missingDepsCopy[i];
+        var depPathInOpenRA = depsInOpenRA[i];
+
+        var depPath = System.IO.Path.Combine(depsDir.Path.FullPath, dep);
+        var oraPath = System.IO.Path.Combine(openraRoot, depPathInOpenRA);
+
+        if (!System.IO.File.Exists(oraPath))
+            Error(string.Format("Could not automatically resolve missing dependency '{0}'.", dep));
+        else
+        {
+            if (!auto)
+            {
+                Console.Write(string.Format("Would you like to copy {0} to {1}? [Y/n] ", oraPath, depPath));
+                var input = Console.ReadLine().ToLowerInvariant();
+                if (!string.IsNullOrWhiteSpace(input) && input != "y" && input != "yes")
+                    continue;
+            }
+
+            System.IO.File.Copy(oraPath, depPath, true);
+            if (System.IO.File.Exists(depPath))
+                missingDeps.Remove(dep);
+        }
+    }
+
+    if (missingDeps.Any())
+        throw new Exception(string.Format("Missing {0} dependencies.", missingDeps.Count));
+});
+
+Task("default")
+    .IsDependentOn("deps")
+    .Does(() => {
+        if (IsRunningOnWindows())
+            MSBuild("./OpenRA.Mods.RA2/OpenRA.Mods.RA2.sln", settings => settings.SetConfiguration(configuration));
+        else
+            XBuild("./OpenRA.Mods.RA2/OpenRA.Mods.RA2.sln", settings => settings.SetConfiguration(configuration));
+
+        System.IO.File.Copy("./OpenRA.Mods.RA2/bin/Debug/OpenRA.Mods.RA2.dll", "./OpenRA.Mods.RA2.dll", true);
+});
+
+RunTarget(target);

--- a/make.ps1
+++ b/make.ps1
@@ -1,146 +1,26 @@
-function FindMSBuild
-{
-	$msBuildVersions = @("4.0")
-	foreach ($msBuildVersion in $msBuildVersions)
-	{
-		$key = "HKLM:\SOFTWARE\Microsoft\MSBuild\ToolsVersions\{0}" -f $msBuildVersion
-		$property = Get-ItemProperty $key -ErrorAction SilentlyContinue
-		if ($property -eq $null -or $property.MSBuildToolsPath -eq $null)
-		{
-			continue
-		}
-		$path = Join-Path $property.MSBuildToolsPath -ChildPath "MSBuild.exe"
-		if (Test-Path $path)
-		{
-			return $path
-		}
-	}
-	return $null
-}
-
 if ($args.Length -eq 0)
 {
-	echo "Command list:"
-	echo ""
-	echo "  all             Builds the mod dll."
-	echo "  dependencies    Copies the mod's dependencies into the"
-	echo "                  'OpenRA.Mods.RA2/dependencies' folder."
-	echo ""
-	$command = (Read-Host "Enter command").Split(' ', 2)
+	$command = "default"
 }
-else
+elseif ($args.Length -eq 1)
 {
-	$command = $args
+    $command = $args
+
+    if ($command -eq "help"   -or
+        $command -eq "h"      -or
+        $command -eq "--help" -or
+        $command -eq "-h"     -or
+        $command -eq "/h"     -or
+        $command -eq "/?")
+    {
+        echo "Target list:"
+        echo ""
+        echo "  default   Builds the mod dll."
+        echo "  deps      Copies the mod's dependencies into the"
+        echo "              'OpenRA.Mods.RA2/dependencies' folder."
+        echo ""
+        exit
+    }
 }
 
-if ($command -eq "all")
-{
-	$msBuild = FindMSBuild
-	$msBuildArguments = "/t:Rebuild /nr:false"
-	if ($msBuild -eq $null)
-	{
-		echo "Unable to locate an appropriate version of MSBuild."
-	}
-	else
-	{
-		cd OpenRA.Mods.RA2
-		$proc = Start-Process $msBuild $msBuildArguments -NoNewWindow -PassThru -Wait
-		if ($proc.ExitCode -ne 0)
-		{
-			echo "Build failed. If just the development tools failed to build, try installing Visual Studio. You may also still be able to run the game."
-		}
-		else
-		{
-			echo "Build succeeded."
-		}
-		cd ..
-	}
-}
-elseif ($command -eq "dependencies")
-{
-	cd OpenRA.Mods.RA2\dependencies
-	$targetDir = $PWD
-	if ($args.Length -eq 0)
-	{
-		$OpenRADir = Read-Host "Enter the path to your OpenRA install"
-	}
-	else
-	{
-		$OpenRADir = $command[1]
-	}
-	if (!(Test-Path $OpenRADir))
-	{
-		echo "Given directory does not exist!"
-	}
-	else
-	{
-		cd $OpenRADir
-
-		if (!(Test-Path OpenRA.Game.exe))
-		{
-			echo "Unable to find 'OpenRA.Game.exe'!"
-			echo "You need to build OpenRA first."
-		}
-		else
-		{
-			cp OpenRA.Game.exe $targetDir
-		}
-
-		if (!(Test-Path mods/common/OpenRA.Mods.Common.dll))
-		{
-			echo "Unable to find the 'common' mod (dll)!"
-		}
-		else
-		{
-			cp mods/common/OpenRA.Mods.Common.dll $targetDir
-		}
-
-		if (!(Test-Path mods/ra/OpenRA.Mods.RA.dll))
-		{
-			echo "Unable to find the Red Alert mod (dll)!"
-		}
-		else
-		{
-			cp mods/ra/OpenRA.Mods.RA.dll $targetDir
-		}
-
-		if (!(Test-Path mods/ts/OpenRA.Mods.TS.dll))
-		{
-			echo "Unable to find the Tiberian Sun mod (dll)!"
-		}
-		else
-		{
-			cp mods/ts/OpenRA.Mods.TS.dll $targetDir
-		}
-
-		if (!(Test-Path Eluant.dll))
-		{
-			echo "Unable to find the Eluant dll!"
-		}
-		else
-		{
-			cp Eluant.dll $targetDir
-		}
-
-		cd $targetDir
-		cd ../..
-		echo "Dependencies copied."
-	}
-}
-else
-{
-	echo ("Invalid command '{0}'" -f $command)
-}
-
-if ($args.Length -eq 0)
-{
-	echo "Press enter to continue."
-	while ($true)
-	{
-		if ([System.Console]::KeyAvailable)
-		{
-			break
-		}
-		Start-Sleep -Milliseconds 50
-	}
-}
+cake -target="$command"

--- a/makefile
+++ b/makefile
@@ -1,0 +1,5 @@
+default:
+	cake -target=default
+
+deps:
+	cake -target=deps


### PR DESCRIPTION
This introduces a dependency on [`cake`](http://cakebuild.net/) for those of us who want an easy compilation via `$ make`.
***It does not affect anyone else!***

Compiling via an IDE (or directly with msbuild/xbuild) is unchanged.

I think this is a fair trade-off, especially given the fact not using it doesn't make compilation any more complex than it already is, and doesn't change anything for those who don't know anything about it.

Windows users will want to grab [the `0.13.0` release](https://github.com/cake-build/cake/releases/download/v0.13.0/Cake-bin-v0.13.0.zip) or `choco install cake.portable`.
OS X brew users can `brew install cake`.
Linux people are on their own (just grab the above release and throw it on your `$PATH`?)