### PR TITLE
Clean the death sequence setup up

### DIFF
--- a/sequences/allied-infantry.yaml
+++ b/sequences/allied-infantry.yaml
@@ -78,9 +78,6 @@ adog:
 	die4: # todo: copy of die1
 		Start: 87
 		Length: 14
-	die5: # todo: copy of die1
-		Start: 87
-		Length: 14
 	die6: # todo: copy of die1; art is missing
 		Start: 87
 		Length: 14
@@ -456,12 +453,6 @@ jumpjet:
 		Length: *
 		Tick: 50
 		Facings: 1
-	die5: flameguy
-		Start: 48
-		Length: 59
-		Facings: 1
-		Tick: 80
-# TODO: This is just the death sequence; normally flameguy would run a bit around before dying
 	die6: electro
 		Length: *
 		Facings: 1

--- a/sequences/allied-infantry.yaml
+++ b/sequences/allied-infantry.yaml
@@ -49,8 +49,6 @@ engineer:
 	die6: electro
 		Length: *
 		Tick: 80
-	die-crushed: death_c
-		Length: 4
 	icon: engnicon
 
 adog:
@@ -81,8 +79,6 @@ adog:
 	die6: # todo: copy of die1; art is missing
 		Start: 87
 		Length: 14
-	die-crushed: death_c
-		Length: 4
 	shoot: adogp
 		Length: 1
 		Facings: 64
@@ -151,8 +147,6 @@ e1:
 	die6: electro
 		Length: *
 		Tick: 80
-	die-crushed: death_c
-		Length: 4
 	shoot:
 		Start: 164
 		Length: 6
@@ -210,9 +204,6 @@ snipe:
 	die6: electro
 		Length: *
 		Tick: 80
-	die-crushed: death_c
-		Length: 4
-		Tick: 80
 	shoot:
 		Start: 164
 		Length: 6
@@ -257,9 +248,6 @@ spy:
 		Tick: 50
 	die6: electro
 		Length: *
-		Tick: 80
-	die-crushed: death_c
-		Length: 4
 		Tick: 80
 	shoot:
 		Start: 164
@@ -321,9 +309,6 @@ seal: # TODO: seala on SNOW
 		Tick: 50
 	die6: electro
 		Length: *
-		Tick: 80
-	die-crushed: death_c
-		Length: 4
 		Tick: 80
 	shoot:
 		Start: 164
@@ -391,9 +376,6 @@ tany:
 	die6: electro
 		Length: *
 		Tick: 80
-	die-crushed: death_c
-		Length: 4
-		Tick: 80
 	shoot:
 		Start: 164
 		Length: 6
@@ -455,10 +437,6 @@ jumpjet:
 		Facings: 1
 	die6: electro
 		Length: *
-		Facings: 1
-		Tick: 80
-	die-crushed: death_c
-		Length: 4
 		Facings: 1
 		Tick: 80
 	shoot:

--- a/sequences/civilians.yaml
+++ b/sequences/civilians.yaml
@@ -32,8 +32,6 @@ civ1:
 	die6: electro
 		Length: *
 		Tick: 80
-	die-crushed: death_c
-		Length: 4
 	cheer:
 		Start: 230
 		Length: 15
@@ -80,8 +78,6 @@ civ2:
 	die6: electro
 		Length: *
 		Tick: 80
-	die-crushed: death_c
-		Length: 4
 	cheer:
 		Start: 230
 		Length: 15
@@ -128,8 +124,6 @@ civ3:
 	die6: electro
 		Length: *
 		Tick: 80
-	die-crushed: death_c
-		Length: 4
 	cheer:
 		Start: 228
 		Length: 15
@@ -184,8 +178,6 @@ vladimir:
 	die6: electro
 		Length: *
 		Tick: 80
-	die-crushed: death_c
-		Length: 4
 	cheer:
 		Start: 56
 		Length: 15
@@ -234,8 +226,6 @@ pentgen:
 	die6: electro
 		Length: *
 		Tick: 80
-	die-crushed: death_c
-		Length: 4
 	cheer:
 		Start: 56
 		Length: 15
@@ -280,8 +270,6 @@ pres:
 	die6: electro
 		Length: *
 		Tick: 80
-	die-crushed: death_c
-		Length: 4
 	cheer:
 		Start: 56
 		Length: 15
@@ -330,8 +318,6 @@ ssrv:
 	die6: electro
 		Length: *
 		Tick: 80
-	die-crushed: death_c
-		Length: 4
 	cheer:
 		Start: 56
 		Length: 15
@@ -380,8 +366,6 @@ civa:
 	die6: electro
 		Length: *
 		Tick: 80
-	die-crushed: death_c
-		Length: 4
 	cheer:
 		Start: 56
 		Length: 15
@@ -430,8 +414,6 @@ civb:
 	die6: electro
 		Length: *
 		Tick: 80
-	die-crushed: death_c
-		Length: 4
 	cheer:
 		Start: 56
 		Length: 15
@@ -480,8 +462,6 @@ civc:
 	die6: electro
 		Length: *
 		Tick: 80
-	die-crushed: death_c
-		Length: 4
 	cheer:
 		Start: 56
 		Length: 15
@@ -526,8 +506,6 @@ civbbp:
 	die6: electro
 		Length: *
 		Tick: 80
-	die-crushed: death_c
-		Length: 4
 	cheer:
 		Start: 56
 		Length: 15
@@ -572,8 +550,6 @@ civbfm:
 	die6: electro
 		Length: *
 		Tick: 80
-	die-crushed: death_c
-		Length: 4
 	cheer:
 		Start: 56
 		Length: 15
@@ -618,8 +594,6 @@ civbf:
 	die6: electro
 		Length: *
 		Tick: 80
-	die-crushed: death_c
-		Length: 4
 	cheer:
 		Start: 56
 		Length: 15
@@ -664,8 +638,6 @@ civbtm:
 	die6: electro
 		Length: *
 		Tick: 80
-	die-crushed: death_c
-		Length: 4
 	cheer:
 		Start: 56
 		Length: 15
@@ -714,8 +686,6 @@ civsfm:
 	die6: electro
 		Length: *
 		Tick: 80
-	die-crushed: death_c
-		Length: 4
 	cheer:
 		Start: 56
 		Length: 15
@@ -764,8 +734,6 @@ civsf:
 	die6: electro
 		Length: *
 		Tick: 80
-	die-crushed: death_c
-		Length: 4
 	cheer:
 		Start: 56
 		Length: 15
@@ -814,8 +782,6 @@ civstm:
 	die6: electro
 		Length: *
 		Tick: 80
-	die-crushed: death_c
-		Length: 4
 	cheer:
 		Start: 56
 		Length: 15

--- a/sequences/soviet-infantry.yaml
+++ b/sequences/soviet-infantry.yaml
@@ -26,8 +26,6 @@ dog:
 	die6: # todo: copy of die1; art is missing
 		Start: 87
 		Length: 14
-	die-crushed: death_c
-		Length: 4
 	shoot: dogp
 		Length: 1
 		Facings: 64
@@ -88,8 +86,6 @@ e2:
 	die6: electro
 		Length: *
 		Tick: 80
-	die-crushed: death_c
-		Length: 4
 	shoot:
 		Start: 164
 		Length: 6
@@ -139,8 +135,6 @@ flakt:
 	die6: electro
 		Length: *
 		Tick: 80
-	die-crushed: death_c
-		Length: 4
 	shoot:
 		Start: 116
 		Length: 6
@@ -188,8 +182,6 @@ shk:
 	die6: electro
 		Length: *
 		Tick: 80
-	die-crushed: death_c
-		Length: 4
 	shoot:
 		Start: 164
 		Length: 6
@@ -238,9 +230,6 @@ terror:
 	die6: electro
 		Length: *
 		Tick: 80
-	die-crushed: death_c
-		Length: 4
-		Tick: 80
 	shoot:
 		Start: 164
 		Length: 6
@@ -287,9 +276,6 @@ deso:
 	die6: electro
 		Length: *
 		Tick: 80
-	die-crushed: death_c
-		Length: 4
-		Tick: 80
 	shoot:
 		Start: 164
 		Length: 6
@@ -334,9 +320,6 @@ ivan:
 		Tick: 50
 	die6: electro
 		Length: *
-		Tick: 80
-	die-crushed: death_c
-		Length: 4
 		Tick: 80
 	shoot:
 		Start: 164

--- a/sequences/soviet-infantry.yaml
+++ b/sequences/soviet-infantry.yaml
@@ -23,9 +23,6 @@ dog:
 	die4: # todo: copy of die1
 		Start: 87
 		Length: 14
-	die5: # todo: copy of die1
-		Start: 87
-		Length: 14
 	die6: # todo: copy of die1; art is missing
 		Start: 87
 		Length: 14


### PR DESCRIPTION
- Removed the redundant `die5` sequence
- Remove die-crushed as we don't use* it and the original doesn't have it

*[search?q=CrushedSequence](https://github.com/OpenRA/ra2/search?utf8=%E2%9C%93&q=CrushedSequence) shows no results and [the default is `null`](https://github.com/OpenRA/OpenRA/blob/d97d02b97f2855bddd17d51bc3b917bfdcee21c2/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs#L36).