### PR TITLE
Fix the asset browser crashing instead of displaying an error

### DIFF
--- a/chrome/assetbrowser.yaml
+++ b/chrome/assetbrowser.yaml
@@ -100,6 +100,13 @@ Background@ASSETBROWSER_PANEL:
 					Width: PARENT_RIGHT
 					Height: PARENT_BOTTOM
 					AspectRatio: 1
+				Label@ERROR:
+					X: 5
+					Width: 490 - 10
+					Height: 330
+					Align: Center
+					Visible: false
+					Text: Error displaying {filename} check assetbrowser.log
 		Container@FRAME_SELECTOR:
 			X: 190
 			Y: 425


### PR DESCRIPTION
Depends on https://github.com/OpenRA/OpenRA/pull/12098.
Fixes #292.