### PR TITLE
Fix Metadata for the Installer

### DIFF
--- a/installer/firstdecade.yaml
+++ b/installer/firstdecade.yaml
@@ -1,0 +1,85 @@
+﻿tfd: C&C The First Decade (English)
+	IDFiles:
+		data1.hdr: bef3a08c3fc1b1caf28ca0dbb97c1f900005930e
+	Install:
+		extract-iscab: data1.hdr
+			Volumes:
+				7: data7.cab
+				8: data8.cab
+			Extract:
+				^Content/ra2/theme.mix: Red Alert 2\RA2\theme.mix
+				^Content/ra2/ra2.mix: Red Alert 2\RA2\ra2.mix
+				^Content/ra2/language.mix: Red Alert 2\RA2\language.mix
+		extract-raw: ^Content/ra2/ra2.mix
+			^Content/ra2/cache.mix:
+				Offset: 348
+				Length: 196632
+			^Content/ra2/conquer.mix:
+				Offset: 196988
+				Length: 16284016
+			^Content/ra2/isosnow.mix:
+				Offset: 16481004
+				Length: 28758698
+			^Content/ra2/isogen.mix:
+				Offset: 45239708
+				Length: 11992046
+			^Content/ra2/isotemp.mix:
+				Offset: 57231756
+				Length: 29171410
+			^Content/ra2/isourb.mix:
+				Offset: 86403180
+				Length: 31811402
+			^Content/ra2/local.mix:
+				Offset: 118214588
+				Length: 34793784
+			^Content/ra2/load.mix:
+				Offset: 153008380
+				Length: 25478184
+			^Content/ra2/neutral.mix:
+				Offset: 178486572
+				Length: 45571600
+			^Content/ra2/sidec01.mix:
+				Offset: 224058172
+				Length: 2099412
+			^Content/ra2/sidec02.mix:
+				Offset: 226157596
+				Length: 2102564
+			^Content/ra2/sidenc01.mix:
+				Offset: 228260172
+				Length: 6935164
+			^Content/ra2/sidenc02.mix:
+				Offset: 235195340
+				Length: 6974140
+			^Content/ra2/snow.mix:
+				Offset: 242169484
+				Length: 18421274
+			^Content/ra2/sno.mix:
+				Offset: 260590764
+				Length: 10898
+			^Content/ra2/generic.mix:
+				Offset: 260601676
+				Length: 15810386
+			^Content/ra2/tem.mix:
+				Offset: 276412076
+				Length: 10850
+			^Content/ra2/temperat.mix:
+				Offset: 276422940
+				Length: 2728266
+			^Content/ra2/urb.mix:
+				Offset: 279151212
+				Length: 10850
+			^Content/ra2/urban.mix:
+				Offset: 279162076
+				Length: 2726218
+		delete: ^Content/ra2/ra2.mix
+		extract-raw: ^Content/ra2/language.mix
+			^Content/ra2/audio.mix:
+				Offset: 164
+				Length: 37456674
+			^Content/ra2/grfxtxt.shp:
+				Offset: 52312452
+				Length: 195432
+			^Content/ra2/cameo.mix:
+				Offset: 52507892
+				Length: 608120
+		delete: ^Content/ra2/language.mix

--- a/installer/origin.yaml
+++ b/installer/origin.yaml
@@ -1,0 +1,80 @@
+﻿origin: C&C The Ultimate Collection (Origin)
+	Type: Install
+	RegistryKey: HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\ea games\Command and Conquer Red Alert II
+	RegistryValue: Install Dir
+	IDFiles:
+		theme.mix: 184f99e3292ab19c71c08a1ad7097ce739396190
+	Install:
+		copy: .
+			^Content/ra2/theme.mix: theme.mix
+		extract-raw: ra2.mix
+			^Content/ra2/cache.mix:
+				Offset: 348
+				Length: 196632
+			^Content/ra2/conquer.mix:
+				Offset: 196988
+				Length: 16284016
+			^Content/ra2/isosnow.mix:
+				Offset: 16481004
+				Length: 28758698
+			^Content/ra2/isogen.mix:
+				Offset: 45239708
+				Length: 11992046
+			^Content/ra2/isotemp.mix:
+				Offset: 57231756
+				Length: 29171410
+			^Content/ra2/isourb.mix:
+				Offset: 86403180
+				Length: 31811402
+			^Content/ra2/local.mix:
+				Offset: 118214588
+				Length: 34793784
+			^Content/ra2/load.mix:
+				Offset: 153008380
+				Length: 25478184
+			^Content/ra2/neutral.mix:
+				Offset: 178486572
+				Length: 45571600
+			^Content/ra2/sidec01.mix:
+				Offset: 224058172
+				Length: 2099412
+			^Content/ra2/sidec02.mix:
+				Offset: 226157596
+				Length: 2102564
+			^Content/ra2/sidenc01.mix:
+				Offset: 228260172
+				Length: 6935164
+			^Content/ra2/sidenc02.mix:
+				Offset: 235195340
+				Length: 6974140
+			^Content/ra2/snow.mix:
+				Offset: 242169484
+				Length: 18421274
+			^Content/ra2/sno.mix:
+				Offset: 260590764
+				Length: 10898
+			^Content/ra2/generic.mix:
+				Offset: 260601676
+				Length: 15810386
+			^Content/ra2/tem.mix:
+				Offset: 276412076
+				Length: 10850
+			^Content/ra2/temperat.mix:
+				Offset: 276422940
+				Length: 2728266
+			^Content/ra2/urb.mix:
+				Offset: 279151212
+				Length: 10850
+			^Content/ra2/urban.mix:
+				Offset: 279162076
+				Length: 2726218
+		extract-raw: language.mix
+			^Content/ra2/audio.mix:
+				Offset: 164
+				Length: 38391794
+			^Content/ra2/grfxtxt.shp:
+				Offset: 53280212
+				Length: 195432
+			^Content/ra2/cameo.mix:
+				Offset: 53475652
+				Length: 608120

--- a/installer/ra2.yaml
+++ b/installer/ra2.yaml
@@ -1,0 +1,165 @@
+﻿ra2: Red Alert 2 (Allied or Soviet Disc, English)
+	IDFiles:
+		readme.txt: e125e2742509d73b20dc4aa65b22497c805cd6f5
+	Install:
+		copy: .
+			^Content/ra2/theme.mix: theme.mix
+		extract-mscab: install/game1.cab
+			^Content/ra2/ra2.mix: ra2.mix
+			^Content/ra2/language.mix: language.mix
+		extract-raw: ^Content/ra2/ra2.mix
+			^Content/ra2/cache.mix:
+				Offset: 348
+				Length: 196632
+			^Content/ra2/conquer.mix:
+				Offset: 196988
+				Length: 16284016
+			^Content/ra2/isosnow.mix:
+				Offset: 16481004
+				Length: 28758698
+			^Content/ra2/isogen.mix:
+				Offset: 45239708
+				Length: 11992046
+			^Content/ra2/isotemp.mix:
+				Offset: 57231756
+				Length: 29171410
+			^Content/ra2/isourb.mix:
+				Offset: 86403180
+				Length: 31811402
+			^Content/ra2/local.mix:
+				Offset: 118214588
+				Length: 34793784
+			^Content/ra2/load.mix:
+				Offset: 153008380
+				Length: 25478184
+			^Content/ra2/neutral.mix:
+				Offset: 178486572
+				Length: 45571600
+			^Content/ra2/sidec01.mix:
+				Offset: 224058172
+				Length: 2099412
+			^Content/ra2/sidec02.mix:
+				Offset: 226157596
+				Length: 2102564
+			^Content/ra2/sidenc01.mix:
+				Offset: 228260172
+				Length: 6935164
+			^Content/ra2/sidenc02.mix:
+				Offset: 235195340
+				Length: 6974140
+			^Content/ra2/snow.mix:
+				Offset: 242169484
+				Length: 18421274
+			^Content/ra2/sno.mix:
+				Offset: 260590764
+				Length: 10898
+			^Content/ra2/generic.mix:
+				Offset: 260601676
+				Length: 15810386
+			^Content/ra2/tem.mix:
+				Offset: 276412076
+				Length: 10850
+			^Content/ra2/temperat.mix:
+				Offset: 276422940
+				Length: 2728266
+			^Content/ra2/urb.mix:
+				Offset: 279151212
+				Length: 10850
+			^Content/ra2/urban.mix:
+				Offset: 279162076
+				Length: 2726218
+		delete: ^Content/ra2/ra2.mix
+		extract-raw: ^Content/ra2/language.mix
+			^Content/ra2/audio.mix:
+				Offset: 164
+				Length: 38391794
+			^Content/ra2/grfxtxt.shp:
+				Offset: 53280212
+				Length: 195432
+			^Content/ra2/cameo.mix:
+				Offset: 53475652
+				Length: 608120
+		delete: ^Content/ra2/language.mix
+
+ra2-linux: Red Alert 2 (Allied or Soviet Disc, English)
+	IDFiles:
+		readme.txt: e125e2742509d73b20dc4aa65b22497c805cd6f5
+	Install:
+		copy: .
+			^Content/ra2/theme.mix: theme.mix
+		extract-mscab: install/game1.cab
+			^Content/ra2/ra2.mix: ra2.mix
+			^Content/ra2/language.mix: language.mix
+		extract-raw: ^Content/ra2/ra2.mix
+			^Content/ra2/cache.mix:
+				Offset: 348
+				Length: 196632
+			^Content/ra2/conquer.mix:
+				Offset: 196988
+				Length: 16284016
+			^Content/ra2/isosnow.mix:
+				Offset: 16481004
+				Length: 28758698
+			^Content/ra2/isogen.mix:
+				Offset: 45239708
+				Length: 11992046
+			^Content/ra2/isotemp.mix:
+				Offset: 57231756
+				Length: 29171410
+			^Content/ra2/isourb.mix:
+				Offset: 86403180
+				Length: 31811402
+			^Content/ra2/local.mix:
+				Offset: 118214588
+				Length: 34793784
+			^Content/ra2/load.mix:
+				Offset: 153008380
+				Length: 25478184
+			^Content/ra2/neutral.mix:
+				Offset: 178486572
+				Length: 45571600
+			^Content/ra2/sidec01.mix:
+				Offset: 224058172
+				Length: 2099412
+			^Content/ra2/sidec02.mix:
+				Offset: 226157596
+				Length: 2102564
+			^Content/ra2/sidenc01.mix:
+				Offset: 228260172
+				Length: 6935164
+			^Content/ra2/sidenc02.mix:
+				Offset: 235195340
+				Length: 6974140
+			^Content/ra2/snow.mix:
+				Offset: 242169484
+				Length: 18421274
+			^Content/ra2/sno.mix:
+				Offset: 260590764
+				Length: 10898
+			^Content/ra2/generic.mix:
+				Offset: 260601676
+				Length: 15810386
+			^Content/ra2/tem.mix:
+				Offset: 276412076
+				Length: 10850
+			^Content/ra2/temperat.mix:
+				Offset: 276422940
+				Length: 2728266
+			^Content/ra2/urb.mix:
+				Offset: 279151212
+				Length: 10850
+			^Content/ra2/urban.mix:
+				Offset: 279162076
+				Length: 2726218
+		delete: ^Content/ra2/ra2.mix
+		extract-raw: ^Content/ra2/language.mix
+			^Content/ra2/audio.mix:
+				Offset: 164
+				Length: 38391794
+			^Content/ra2/grfxtxt.shp:
+				Offset: 53280212
+				Length: 195432
+			^Content/ra2/cameo.mix:
+				Offset: 53475652
+				Length: 608120
+		delete: ^Content/ra2/language.mix

--- a/mod.yaml
+++ b/mod.yaml
@@ -15,8 +15,6 @@ Packages:
 	$d2k: d2k
 	$ts: ts
 	./mods/common: common
-	~ra2.mix
-	~language.mix
 	~multi.mix
 	~audio.mix
 	~cache.mix
@@ -27,9 +25,11 @@ Packages:
 	~isosnow.mix
 	~isotemp.mix
 	~isourb.mix
+	~language.mix
 	~load.mix
 	~local.mix
 	~neutral.mix
+	~ra2.mix
 	~sidec01.mix
 	~sidec02.mix
 	~sno.mix
@@ -253,56 +253,16 @@ GameSpeeds:
 
 ModContent:
 	InstallPromptMessage: Red Alert 2 requires artwork and audio from the original game.
-	HeaderMessage: The original game content must be copied from an original game disc.
+	HeaderMessage: Game content must be extracted from the original game discs or an\nexisting digital install of RA2.
 	Packages:
 		base: Base Game Files
-			TestFiles: ^Content/ra2/ra2.mix, ^Content/ra2/language.mix
+			TestFiles: ^Content/ra2/cameo.mix, ^Content/ra2/local.mix
 			Sources: ra2, ra2-linux, origin, tfd
 			Required: true
 		music: Base Game Music
 			TestFiles: ^Content/ra2/theme.mix
 			Sources: ra2, ra2-linux, origin, tfd
 	Sources:
-		ra2: Red Alert 2 (Allied or Soviet Disc, English)
-			IDFiles:
-				README.txt: e125e2742509d73b20dc4aa65b22497c805cd6f5
-			Install:
-				copy: .
-					^Content/ra2/theme.mix: theme.mix
-				extract-mscab: INSTALL/Game1.CAB
-					^Content/ra2/ra2.mix: ra2.mix
-					^Content/ra2/language.mix: language.mix
-		ra2-linux: Red Alert 2 (Allied or Soviet Disc, English)
-			IDFiles:
-				readme.txt: e125e2742509d73b20dc4aa65b22497c805cd6f5
-			Install:
-				copy: .
-					^Content/ra2/theme.mix: theme.mix
-				extract-mscab: install/game1.cab
-					^Content/ra2/ra2.mix: ra2.mix
-					^Content/ra2/language.mix: language.mix
-		origin: C&C The Ultimate Collection (Origin)
-			Type: Install
-			RegistryKey: HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\ea games\Command and Conquer Red Alert II
-			RegistryValue: Install Dir
-			IDFiles:
-				theme.mix: 184f99e3292ab19c71c08a1ad7097ce739396190
-			Install:
-				copy: .
-					^Content/ra2/theme.mix: theme.mix
-					^Content/ra2/ra2.mix: ra2.mix
-					^Content/ra2/language.mix: language.mix
-		tfd: C&C The First Decade (English)
-			IDFiles:
-				data1.hdr: bef3a08c3fc1b1caf28ca0dbb97c1f900005930e
-				data7.cab: 49ded3814a0463874994a1af578559388811a85a
-				data8.cab: bcf912735e5c9c43372f5e9d0d2b3a761cb8675e
-			Install:
-				extract-iscab: data1.hdr
-					Volumes:
-						7: data7.cab
-						8: data8.cab
-					Extract:
-						^Content/ra2/theme.mix: Red Alert 2\RA2\theme.mix
-						^Content/ra2/ra2.mix: Red Alert 2\RA2\ra2.mix
-						^Content/ra2/language.mix: Red Alert 2\RA2\language.mix
+		ra2|installer/firstdecade.yaml
+		ra2|installer/origin.yaml
+		ra2|installer/ra2.yaml


### PR DESCRIPTION
This Pr fixes the crash when clicking the "Advanced Installation" Button in the Content installer and write a proper Installer Scheme.

closes  #296

![ra2_test](https://cloud.githubusercontent.com/assets/2057932/18924154/660ede30-85af-11e6-9ade-8f8cfa18db8f.png)
