### PR TITLE
fix missing IRenderInfantrySequenceModifier building against the 'bleed' branch of OpenRA engine

### DIFF
--- a/OpenRA.Mods.RA2/Traits/Render/WithSwimSuit.cs
+++ b/OpenRA.Mods.RA2/Traits/Render/WithSwimSuit.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using OpenRA.Traits;
+using OpenRA.Mods.Common.Traits;
 
 namespace OpenRA.Mods.RA2.Traits
 {


### PR DESCRIPTION
I was trying to build the ra2 mod against the latest 'bleed' branch of the OpenRA engine but got:

> owwlo@owwlo-XPS-13-9343:~/build/OpenRA/mods/ra2/OpenRA.Mods.RA2$ xbuild 
> XBuild Engine Version 12.0
> Mono, Version 4.2.1.0
> Copyright (C) 2005-2013 Various Mono authors
> ......
>         Traits/Render/WithSwimSuit.cs(25,30): error CS0246: The type or namespace name 'IRenderInfantrySequenceModifier' could not be found. Are you missing `OpenRA.Mods.Common.Traits' using directive?
>          0 Warning(s)
>          1 Error(s)

My OS:

> Distributor ID: Ubuntu
> Description:    Ubuntu 16.04.1 LTS
> Release:        16.04
> Codename:       xenial

I also tried building on trusty but got the same error.