### PR TITLE
Parameter Fixed

### DIFF
--- a/OpenRA.Mods.RA2/Activities/ChronoResourceTeleport.cs
+++ b/OpenRA.Mods.RA2/Activities/ChronoResourceTeleport.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.RA2.Activities
 				self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(sourcepos, w, image, info.WarpInSequence, info.Palette)));
 
 			if (info.WarpInSound != null)
-				Game.Sound.Play(info.WarpInSound, self.CenterPosition);
+				Game.Sound.Play((SoundType)System.Enum.Parse(typeof(SoundType),info.WarpInSound,true), self.CenterPosition.ToString());
 
 			self.Trait<IPositionable>().SetPosition(self, destination);
 			self.Generation++;
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.RA2.Activities
 				self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(destinationpos, w, image, info.WarpOutSequence, info.Palette)));
 
 			if (info.WarpOutSound != null)
-				Game.Sound.Play(info.WarpOutSound, self.CenterPosition);
+                Game.Sound.Play((SoundType)System.Enum.Parse(typeof(SoundType), info.WarpInSound, true), self.CenterPosition.ToString());
 
 			return NextActivity;
 		}


### PR DESCRIPTION
Fix the parameter type error for Game.Sound.Play function, because the new OpenRA has changed the parameter type to enum SoundType  not string