### PR TITLE
Abuse 'ls' to determine if content directory is empty

### DIFF
--- a/fetch-content.sh
+++ b/fetch-content.sh
@@ -9,7 +9,7 @@ else
 	DIR="$HOME/.openra/Content/ra2/"
 fi
 
-if [ ! -e "$DIR" ]; then
+if [ -z "$(ls -A "$DIR")" ]; then
 	echo "Downloading RA2 mod content"
 
 	mkdir -p "$DIR"


### PR DESCRIPTION
The directory existing is completely valid.
We want to know whether or not the directory is _empty_.