### PR TITLE
Adds faction descriptions

### DIFF
--- a/rules/world.yaml
+++ b/rules/world.yaml
@@ -31,38 +31,47 @@
 		Name: America
 		InternalName: america
 		Side: Allies
+		Description: America\nSpecial Ability: Paratroopers
 	Faction@2:
 		Name: Germany
 		InternalName: germany
 		Side: Allies
+		Description: Germany\nSpecial Vehicle: Tank Destroyer
 	Faction@3:
 		Name: England
 		InternalName: england
 		Side: Allies
+		Description: England\nSpecial Infantry: Sniper
 	Faction@4:
 		Name: France
 		InternalName: france
 		Side: Allies
+		Description: France\nSpecial Building: Grand Cannon
 	Faction@5:
 		Name: Korea
 		InternalName: korea
 		Side: Allies
+		Description: Korea\nSpecial Aircraft: Black Eagle
 	Faction@6:
 		Name: Cuba
 		InternalName: cuba
 		Side: Soviets
+		Description: Cuba\nSpecial Infantry: Terrorist
 	Faction@7:
 		Name: Libya
 		InternalName: libya
 		Side: Soviets
+		Description: Libya\nSpecial Vehicle: Demolition Truck
 	Faction@8:
 		Name: Iraq
 		InternalName: iraq
 		Side: Soviets
+		Description: Iraq\nSpecial Infantry: Desolator
 	Faction@9:
 		Name: Russia
 		InternalName: russia
 		Side: Soviets
+		Description: Russia\nSpecial Vehicle: Tesla Tank
 	ResourceType@Ore:
 		ResourceType: 1
 		Palette: resource


### PR DESCRIPTION
I noticed these were missing, so I added them. As far as I'm aware, these are the only notable differences between the factions. I opted for more specific unit descriptions (Special Infantry/Vehicle/Aircraft/Building) over the generic "Special Unit" used in other mods. This seems clearer for those not already familiar with the units.