### PR TITLE
Fall back to curl if wget is missing

### DIFF
--- a/fetch-content.sh
+++ b/fetch-content.sh
@@ -3,20 +3,36 @@
 # Die on any error for Travis CI to automatically retry:
 set -e
 
+function download_url() {
+  URL="$1"
+  LOCAL_FILE="${1##*/}"
+  if [ -x "$(type -p wget)" ]; then
+    wget -O "${LOCAL_FILE}" "${URL}"
+  elif [ -x "$(type -p curl)" ]; then
+    curl -f -o "${LOCAL_FILE}" "${URL}"
+  else
+    echo "No supported download method found." 1>&2
+    return 1
+  fi
+}
+
 if [ "$(uname)" == "Darwin" ]; then
-	DIR="$HOME/Library/Application Support/OpenRA/Content/ra2/"
+  DIR="$HOME/Library/Application Support/OpenRA/Content/ra2"
 else
-	DIR="$HOME/.openra/Content/ra2/"
+  DIR="$HOME/.openra/Content/ra2"
 fi
 
-if [ ! -e "$DIR" ]; then
-	echo "Downloading RA2 mod content"
-
-	mkdir -p "$DIR"
-	pushd "$DIR"
-
-	wget http://xwis.net/downloads/Red-Alert-2-Multiplayer.exe
-	7z e Red-Alert-2-Multiplayer.exe
-	rm *.exe *.dll *.DLL *.wav *.mmp *.CFG *.WAR *.cache
-	popd
-fi
+#if the directory already exists then exit
+[ ! -d "${DIR}" ] && mkdir -p "${DIR}" || {
+  cd "${DIR}"
+  #only exit if there's existing content
+  if ls *.mix &> /dev/null; then
+    exit 0
+  fi
+}
+echo "Downloading RA2 mod content"
+cd "${DIR}"
+#download the file else exit non-zero
+download_url "http://xwis.net/downloads/Red-Alert-2-Multiplayer.exe"
+7z e Red-Alert-2-Multiplayer.exe
+rm *.exe *.dll *.DLL *.wav *.mmp *.CFG *.WAR *.cache

--- a/fetch-content.sh
+++ b/fetch-content.sh
@@ -6,9 +6,9 @@ set -e
 function download_url() {
   URL="$1"
   LOCAL_FILE="${1##*/}"
-  if [ -x "$(type -p wget)" ]; then
+  if [ -x "$(type -P wget)" ]; then
     wget -O "${LOCAL_FILE}" "${URL}"
-  elif [ -x "$(type -p curl)" ]; then
+  elif [ -x "$(type -P curl)" ]; then
     curl -f -o "${LOCAL_FILE}" "${URL}"
   else
     echo "No supported download method found." 1>&2


### PR DESCRIPTION
Supersedes #382.  

Bugfixes which were bugs in the old script:

- Mac OS doesn't come with `wget` by default, but it does come with `curl`.
- If the ra2 content directory existed, then the script would skip attempting to download even if there was no content.  Fixes `travis_retry ~/.openra/mods/ra2/fetch-content.sh` in `.travis.yml`.
- If `wget` was attempted more than once and the download file already exists, then `wget` will download `Red-Alert-2-Multiplayer.exe.1` and so on.  `wget -O` forces download to `Red-Alert-2-Multiplayer.exe`.