### PR TITLE
Remove unused private field

### DIFF
--- a/OpenRA.Mods.RA2/Traits/Render/WithExitOverlay.cs
+++ b/OpenRA.Mods.RA2/Traits/Render/WithExitOverlay.cs
@@ -38,14 +38,12 @@ namespace OpenRA.Mods.RA2.Traits
 
 	public class WithExitOverlay : INotifyDamageStateChanged, INotifyBuildComplete, INotifySold, INotifyProduction, ITick
 	{
-		readonly Actor self;
 		readonly Animation overlay;
 		bool buildComplete, enable;
 		CPos exit;
 
 		public WithExitOverlay(Actor self, WithExitOverlayInfo info)
 		{
-			this.self = self;
 			var rs = self.Trait<RenderSprites>();
 			var body = self.Trait<BodyOrientation>();
 


### PR DESCRIPTION
This generates a compile warning, which is treated as an error when invoking 'make' on Linux.
Thus making the mod able to build again.