### PR TITLE
Allow ore to grow on road terrain

### DIFF
--- a/mods/ra2/rules/world.yaml
+++ b/mods/ra2/rules/world.yaml
@@ -82,7 +82,7 @@
 		Type: Ore
 		Name: Valuable Minerals
 		PipColor: Yellow
-		AllowedTerrainTypes: Clear, Rough
+		AllowedTerrainTypes: Clear, Rough, Road
 		AllowUnderActors: false
 		TerrainType: Ore
 	ResourceType@Gems:
@@ -94,7 +94,7 @@
 		Type: Gems
 		Name: Valuable Minerals
 		PipColor: Red
-		AllowedTerrainTypes: Clear, Rough
+		AllowedTerrainTypes: Clear, Rough, Road
 		AllowUnderActors: false
 		TerrainType: Gems
 


### PR DESCRIPTION
Otherwise Spawn A's starting ore is gone on The Alamo