### PR TITLE
Add Terror Drone

### DIFF
--- a/mods/ra2/rules/allied-vehicles.yaml
+++ b/mods/ra2/rules/allied-vehicles.yaml
@@ -155,9 +155,14 @@ tnkd:
 		Type: Heavy
 	RevealsShroud:
 		Range: 8c0
-	Armament@Primary:
+	Armament@primary:
 		Weapon: sabot
 		LocalOffset: 640,0,384
+		RequiresCondition: !rank-elite
+	Armament@elite:
+		Weapon: sabotE
+		LocalOffset: 640,0,384
+		RequiresCondition: rank-elite
 	AttackFrontal:
 		Voice: Attack
 	AutoTarget:

--- a/mods/ra2/rules/soviet-vehicles.yaml
+++ b/mods/ra2/rules/soviet-vehicles.yaml
@@ -98,6 +98,45 @@ harv:
 		VoiceSet: SovietVehicleVoice
 	HitShape:
 
+dron:
+	Inherits: ^Vehicle
+	Valued:
+		Cost: 500
+	Tooltip:
+		Name: Terror Drone
+	Buildable:
+		Queue: Vehicle
+		BuildPaletteOrder: 40
+		Prerequisites: ~naweap
+		Description: \n  Strong vs Infantry, Vehicles\n  Weak vs Aircraft
+	Mobile:
+		Speed: 105
+		TurnSpeed: 15
+		Crushes: crate
+	Health:
+		HP: 100
+	Armor:
+		Type: Drone
+	RevealsShroud:
+		Range: 4c0
+	Passenger:
+		CargoType: Infantry
+		Weight: 2
+	RenderSprites:
+	-RenderVoxels:
+	WithInfantryBody:
+		StandSequences: stand
+		DefaultAttackSequence: shoot
+	Armament:
+		Weapon: DroneJump
+	AttackLeap:
+		Voice: Attack
+	AutoTarget:
+		InitialStance: AttackAnything
+	Voiced:
+		VoiceSet: TerrorDroneVoice
+	HitShape:
+
 htk:
 	Inherits: ^Vehicle
 	Valued:

--- a/mods/ra2/sequences/vehicles.yaml
+++ b/mods/ra2/sequences/vehicles.yaml
@@ -40,6 +40,27 @@ dest:
 dred:
 	icon: dredicon
 
+dron:
+	stand:
+		Start: 48
+		ShadowStart: 136
+		Facings: -8
+	run:
+		Start: 0
+		ShadowStart: 88
+		Length: 6
+		Facings: -8
+		Tick: 80
+	jump:
+		Start: 56
+		ShadowStart: 144
+		Length: 4
+		Facings: -8
+	shoot: dronp
+		Length: 1
+		Facings: 32
+	icon: dronicon
+
 euroc:
 	icon: xxicon
 

--- a/mods/ra2/weapons/bullets.yaml
+++ b/mods/ra2/weapons/bullets.yaml
@@ -19,6 +19,8 @@ GrandCannonWeapon:
 			Wood: 50
 			Steel: 100
 			Concrete: 50
+			Drone: 100
+			Rocket: 100
 	Warhead@2Eff: CreateEffect
 		Explosions: medium_explosion
 
@@ -43,6 +45,8 @@ sabot:
 			Wood: 2
 			Steel: 2
 			Concrete: 2
+			Drone: 2
+			Rocket: 100
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 
 MirageGun:
@@ -65,6 +69,8 @@ MirageGun:
 			Wood: 30
 			Steel: 20
 			Concrete: 20
+			Drone: 100
+			Rocket: 100
 		DamageTypes: FlameDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: iron_fx
@@ -91,6 +97,7 @@ MirageGunE:
 			Wood: 20
 			Steel: 15
 			Concrete: 10
+			Drone: 200
 
 20mmrapidE:
 	Inherits: ^LargeBullet
@@ -109,6 +116,8 @@ MirageGunE:
 			Wood: 50
 			Steel: 40
 			Concrete: 25
+			Drone: 80
+			Rocket: 100
 		DamageTypes: Prone70Percent, TriggerProne, ExplosionDeath
 
 105mm:
@@ -128,6 +137,8 @@ MirageGunE:
 			Wood: 65
 			Steel: 45
 			Concrete: 60
+			Drone: 60
+			Rocket: 100
 
 105mmE:
 	Inherits: 105mm
@@ -165,6 +176,8 @@ MirageGunE:
 			Wood: 65
 			Steel: 45
 			Concrete: 60
+			Drone: 60
+			Rocket: 100
 
 120mmE:
 	Inherits: 120mm
@@ -236,6 +249,8 @@ MirageGunE:
 			Wood: 100
 			Steel: 80
 			Concrete: 60
+			Drone: 100
+			Rocket: 100
 
 155mmE:
 	Inherits: 155mm

--- a/mods/ra2/weapons/bullets.yaml
+++ b/mods/ra2/weapons/bullets.yaml
@@ -28,7 +28,7 @@ sabot:
 	Inherits: ^LargeBullet
 	ValidTargets: Ground, Water
 	Range: 5c0
-	ReloadDelay: 25
+	ReloadDelay: 70
 	Report: vtadatta.wav, vtadattb.wav, vtadattc.wav
 	Projectile: Bullet
 		Speed: 100c0
@@ -48,6 +48,22 @@ sabot:
 			Drone: 2
 			Rocket: 100
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
+
+sabotE:
+	Inherits: sabot
+	Range: 6c768
+	ReloadDelay: 60
+	Warhead@1Dam: SpreadDamage
+		Damage: 175
+		Versus:
+			Medium: 50
+			Drone: 100
+	Warhead@2Eff: CreateEffect
+		Explosions: elite_explosion
+		ImpactSounds: gexpapoa.wav
+	Warhead@3EffWater: CreateEffect
+		Explosions: large_watersplash
+		ImpactSounds: gexpwala.wav
 
 MirageGun:
 	Inherits: ^LargeBullet

--- a/mods/ra2/weapons/defaults.yaml
+++ b/mods/ra2/weapons/defaults.yaml
@@ -17,6 +17,8 @@
 			Wood: 30
 			Steel: 20
 			Concrete: 10
+			Drone: 100
+			Rocket: 100
 		DamageTypes: Prone100Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: flak_puff
@@ -96,6 +98,8 @@
 			Wood: 0
 			Steel: 0
 			Concrete: 0
+			Drone: 100
+			Rocket: 100
 		DamageTypes: BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: small_bang
@@ -125,6 +129,8 @@
 			Wood: 75
 			Steel: 50
 			Concrete: 25
+			Drone: 100
+			Rocket: 100
 		DamageTypes: Prone70Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: piffpiff
@@ -148,6 +154,8 @@
 			Wood: 50
 			Steel: 50
 			Concrete: 50
+			Drone: 200
+			Rocket: 100
 		DamageTypes: ElectroDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: tesla_impact

--- a/mods/ra2/weapons/explosions.yaml
+++ b/mods/ra2/weapons/explosions.yaml
@@ -50,6 +50,8 @@ IvanBomber:
 			Wood: 20
 			Steel: 100
 			Concrete: 100
+			Drone: 100
+			Rocket: 100
 		DamageTypes: FlameDeath, Prone100Percent
 	Warhead@2Eff: CreateEffect
 		Delay: 100
@@ -83,6 +85,8 @@ TerrorBomb:
 			Wood: 100
 			Steel: 150
 			Concrete: 30
+			Drone: 100
+			Rocket: 100
 		AffectsParent: true
 		DamageTypes: Prone70Percent, TriggerProne, FlameDeath
 	Warhead@2Eff: CreateEffect
@@ -111,6 +115,8 @@ NukePayload:
 			Wood: 60
 			Steel: 100
 			Concrete: 8
+			Drone: 100
+			Rocket: 100
 		AffectsParent: true
 		DamageTypes: Prone50Percent, TriggerProne, RadiationDeath
 	Warhead@2Res_impact: DestroyResource
@@ -170,6 +176,8 @@ demobomb:
 			Wood: 80
 			Steel: 150
 			Concrete: 10
+			Drone: 100
+			Rocket: 100
 		DamageTypes: Prone50Percent, TriggerProne, RadiationDeath
 	Warhead@5Res_areanuke1: DestroyResource
 		Size: 2
@@ -193,6 +201,8 @@ demobomb:
 			Wood: 80
 			Steel: 150
 			Concrete: 10
+			Drone: 100
+			Rocket: 100
 		DamageTypes: Prone50Percent, TriggerProne, RadiationDeath
 	Warhead@8Res_areanuke2: DestroyResource
 		Size: 3
@@ -213,6 +223,8 @@ demobomb:
 			Wood: 80
 			Steel: 150
 			Concrete: 10
+			Drone: 100
+			Rocket: 100
 		DamageTypes: Prone50Percent, TriggerProne, RadiationDeath
 	Warhead@10Res_areanuke3: DestroyResource
 		Size: 4

--- a/mods/ra2/weapons/explosions.yaml
+++ b/mods/ra2/weapons/explosions.yaml
@@ -46,10 +46,10 @@ IvanBomber:
 			Plate: 100
 			Light: 100
 			Medium: 100
-			Heavy: 250
-			Wood: 20
-			Steel: 100
-			Concrete: 100
+			Heavy: 100
+			Wood: 100
+			Steel: 250
+			Concrete: 20
 			Drone: 100
 			Rocket: 100
 		DamageTypes: FlameDeath, Prone100Percent

--- a/mods/ra2/weapons/melee.yaml
+++ b/mods/ra2/weapons/melee.yaml
@@ -17,7 +17,13 @@ DogJaw:
 			Wood: 0
 			Steel: 0
 			Concrete: 0
+			Drone: 0
+			Rocket: 0
 		DamageTypes: BulletDeath
+
+DroneJump:
+	Inherits: DogJaw
+	Report: vteratta.wav
 
 AlligatorBite:
 	ReloadDelay: 30

--- a/mods/ra2/weapons/mgs.yaml
+++ b/mods/ra2/weapons/mgs.yaml
@@ -145,14 +145,3 @@ BlackHawkCannon:
 	Report: vblhatta.wav, vblhattb.wav
 	Warhead@1Dam: SpreadDamage
 		Damage: 25
-		Versus:
-			None: 150
-			Flak: 100
-			Plate: 50
-			Light: 60
-			Medium: 10
-			Heavy: 10
-			Wood: 30
-			Steel: 20
-			Concrete: 10
-		DamageTypes: Prone100Percent, TriggerProne, BulletDeath

--- a/mods/ra2/weapons/mgs.yaml
+++ b/mods/ra2/weapons/mgs.yaml
@@ -74,6 +74,8 @@ DoublePistols:
 			Wood: 0
 			Steel: 0
 			Concrete: 0
+			Drone: 0
+			Rocket: 100
 		DamageTypes: BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: piff

--- a/mods/ra2/weapons/misc.yaml
+++ b/mods/ra2/weapons/misc.yaml
@@ -23,6 +23,8 @@ BlimpBomb:
 			Wood: 85
 			Steel: 75
 			Concrete: 50
+			Drone: 100
+			Rocket: 100
 		DamageTypes: Prone70Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: medium_clsn

--- a/mods/ra2/weapons/missiles.yaml
+++ b/mods/ra2/weapons/missiles.yaml
@@ -29,6 +29,8 @@ MammothTusk:
 			Wood: 75
 			Steel: 40
 			Concrete: 20
+			Drone: 80
+			Rocket: 100
 		DamageTypes: ExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: medium_bang
@@ -107,6 +109,8 @@ HoverMissile:
 			Wood: 75
 			Steel: 40
 			Concrete: 20
+			Drone: 80
+			Rocket: 100
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: small_grey_explosion
@@ -161,6 +165,8 @@ SubTorpedo:
 			Wood: 65
 			Steel: 65
 			Concrete: 60
+			Drone: 25
+			Rocket: 100
 		DamageTypes: ExplosionDeath
 	Warhead@2EffWater: CreateEffect
 		Explosions: large_watersplash

--- a/mods/ra2/weapons/zaps.yaml
+++ b/mods/ra2/weapons/zaps.yaml
@@ -131,6 +131,8 @@ PrismShot:
 			Wood: 50
 			Steel: 50
 			Concrete: 50
+			Drone: 200
+			Rocket: 100
 		DamageTypes: ElectroDeath
 
 Comet:
@@ -155,6 +157,8 @@ Comet:
 			Wood: 200
 			Steel: 200
 			Concrete: 200
+			Drone: 200
+			Rocket: 100
 		DamageTypes: Prone50Percent, TriggerProne, ElectroDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: medium_clsn
@@ -194,6 +198,8 @@ RadBeamWeapon:
 			Wood: 0
 			Steel: 0
 			Concrete: 0
+			Drone: 0 # This is actually 100, but drones are immune to Radiation
+			Rocket: 100
 		DamageTypes: RadiationDeath
 
 RadBeamWeaponE:


### PR DESCRIPTION
For now just works like attack dog. No vehicle targeting. Mostly added as a placeholder unit.

Also defines Drone and Rocket (those were called special_1 and special_2 on original, no reason to use that name here) armor classes on weapons
And some other weapon fixes i noticed while doing that