### PR TITLE
Some parachute fixes

### DIFF
--- a/mods/ra2/rules/aircraft.yaml
+++ b/mods/ra2/rules/aircraft.yaml
@@ -233,6 +233,7 @@ pdplane:
 	Tooltip:
 		Name: Cargo Plane
 	Aircraft:
+		Repulsable: false
 		CruiseAltitude: 5600
 		TurnSpeed: 5
 		Speed: 225

--- a/mods/ra2/rules/defaults.yaml
+++ b/mods/ra2/rules/defaults.yaml
@@ -646,6 +646,17 @@
 		OpeningSequence: open
 		Sequence: idle
 		ClosingSequence: close
+	WithInfantryBody:
+		RequiresCondition: !parachute
+	Targetable:
+		RequiresCondition: !parachute
+	Targetable@airborne:
+		TargetTypes: Air
+		RequiresCondition: parachute
+	WithDeathAnimation@normal:
+		RequiresCondition: !parachute
+	WithDeathAnimation@effect:
+		RequiresCondition: !parachute
 	ExternalCondition@PARACHUTE:
 		Condition: parachute
 

--- a/mods/ra2/rules/defaults.yaml
+++ b/mods/ra2/rules/defaults.yaml
@@ -630,6 +630,7 @@
 
 ^Parachutable:
 	WithSpriteBody@Parachute:
+		Name: parachute
 		Sequence: paradrop
 		RequiresCondition: parachute
 	Parachutable:

--- a/mods/ra2/rules/defaults.yaml
+++ b/mods/ra2/rules/defaults.yaml
@@ -661,6 +661,29 @@
 	ExternalCondition@PARACHUTE:
 		Condition: parachute
 
+^ParachutableVehicle:
+	Parachutable:
+		FallRate: 26
+		KilledOnImpassableTerrain: true
+		GroundCorpseSequence:
+		GroundCorpsePalette:
+		WaterCorpseSequence:
+		WaterCorpsePalette:
+		ParachutingCondition: parachute
+	WithParachute:
+		RequiresCondition: parachute
+		Image: parach
+		OpeningSequence: open
+		Sequence: idle
+		ClosingSequence: close
+	Targetable:
+		RequiresCondition: !parachute
+	Targetable@airborne:
+		TargetTypes: Air
+		RequiresCondition: parachute
+	ExternalCondition@PARACHUTE:
+		Condition: parachute
+
 ^WithSwimSuit:
 	WithInfantryBody:
 		RequiresCondition: !swimming
@@ -774,6 +797,7 @@
 	Inherits@3: ^IronCurtainable
 	Inherits@4: ^ChronoDisable
 	Inherits@5: ^CrateStatModifiers
+	Inherits@6: ^ParachutableVehicle
 	OwnerLostAction:
 		Action: Kill
 	Mobile:

--- a/mods/ra2/rules/soviet-infantry.yaml
+++ b/mods/ra2/rules/soviet-infantry.yaml
@@ -320,6 +320,7 @@ civan:
 
 yuri:
 	Inherits: ^Infantry
+	Inherits@2: ^Parachutable
 	Buildable:
 		Queue: Infantry
 		BuildAtProductionType: Infantry


### PR DESCRIPTION
Makes cargo plane non-repulsable.

Makes paradroped units properly only render paradrop image.

Makes paradropped units properly only target by AA.

Gives ^Parachutible to Yuri and fixes issues with GrantTimedConditionOnDeploy that prevents this.

Adds ^ParachutibleVehicle and gives it to ^Vehicles.