### PR TITLE
Make Adjacent tags match original

### DIFF
--- a/mods/ra2/rules/allied-structures.yaml
+++ b/mods/ra2/rules/allied-structures.yaml
@@ -389,7 +389,7 @@ gayard:
 	Building:
 		Footprint: xxxx xxxx xxxx xxxx
 		Dimensions: 4,4
-		Adjacent: 12
+		Adjacent: 13
 		TerrainTypes: Water
 	-GivesBuildableArea:
 	Health:
@@ -591,6 +591,7 @@ gapill:
 	Building:
 		Footprint: x
 		Dimensions: 1, 1
+		Adjacent: 5
 	Health:
 		HP: 400
 	Armor:
@@ -629,6 +630,7 @@ nasam:
 	Building:
 		Footprint: x
 		Dimensions: 1, 1
+		Adjacent: 5
 	Health:
 		HP: 900
 	Armor:

--- a/mods/ra2/rules/defaults.yaml
+++ b/mods/ra2/rules/defaults.yaml
@@ -125,7 +125,7 @@
 		BuildSounds: uplace.wav
 		UndeploySounds: uselbuil.wav
 		TerrainTypes: Clear, Road, DirtRoad, Rough
-		Adjacent: 4
+		Adjacent: 3
 	FrozenUnderFog:
 	GivesBuildableArea:
 	Capturable:
@@ -266,7 +266,7 @@
 		Dimensions: 1,1
 		Footprint: x
 		BuildSounds: uplace.wav
-		Adjacent: 7
+		Adjacent: 9
 		TerrainTypes: Clear, Rough, Road, DirtRoad
 	BlocksProjectiles:
 	LineBuild:

--- a/mods/ra2/rules/soviet-structures.yaml
+++ b/mods/ra2/rules/soviet-structures.yaml
@@ -347,7 +347,7 @@ nayard:
 	Building:
 		Footprint: xxxx xxxx xxxx xxxx
 		Dimensions: 4,4
-		Adjacent: 12
+		Adjacent: 13
 		TerrainTypes: Water
 	-GivesBuildableArea:
 	Health:
@@ -889,6 +889,7 @@ nalasr:
 	Building:
 		Footprint: x
 		Dimensions: 1, 1
+		Adjacent: 5
 	Health:
 		HP: 400
 	Armor:


### PR DESCRIPTION
ORA and original handles them differently so we need 1 more than what rules.ini says.

For some reason Flak cannon has 2 in original but Patriot has 4. I kept that like that.