### PR TITLE
Make aircraft don't take off after creation and resupply

### DIFF
--- a/mods/ra2/rules/defaults.yaml
+++ b/mods/ra2/rules/defaults.yaml
@@ -580,7 +580,6 @@
 		Voice: Move
 		AirborneCondition: airborne
 		CanHover: True
-		TakeOffOnResupply: true
 		VTOL: true
 	HiddenUnderFog:
 		Type: CenterPosition
@@ -619,6 +618,8 @@
 		CruiseAltitude: 5600
 		CruisingCondition: cruising
 		AltitudeVelocity: 120
+		LandWhenIdle: false
+		TakeOffOnCreation: false
 	Hovers@CRUISING:
 		RequiresCondition: cruising
 	ReturnOnIdle:


### PR DESCRIPTION
They are currently entering a loop of taking off and landing bacause of ReturnOnIdle. Also this matches the original game's behaviour.