### PR TITLE
Fix engine downloading on Windows

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -329,6 +329,7 @@ if ($command -eq "all" -or $command -eq "clean")
 		$dlPath = Join-Path $dlPath (Split-Path -leaf $env:AUTOMATIC_ENGINE_TEMP_ARCHIVE_NAME)
 
 		$client = new-object System.Net.WebClient
+		[Net.ServicePointManager]::SecurityProtocol = 'Tls12'
 		$client.DownloadFile($url, $dlPath)
 
 		Add-Type -assembly "system.io.compression.filesystem"


### PR DESCRIPTION
Kinda fixes #453. Without updating the engine to include https://github.com/OpenRA/OpenRA/pull/14855 installing dependencies would still fail. Still better to have this fixed, as you can just copy-paste the thirdparty folder from another installment.