### PR TITLE
Fix: Ra2 no longer crashes when opening the multiplayer menu

### DIFF
--- a/mods/ra2/chrome.yaml
+++ b/mods/ra2/chrome.yaml
@@ -1050,6 +1050,21 @@ strategic: strategic.png
 	enemy_owned: 32,32,32,32
 	player_owned: 96,0,32,32
 
+reload-icon: chrome.png
+	enabled: 512,80,16,16
+	disabled-0: 512,64,16,16
+	disabled-1: 528,64,16,16
+	disabled-2: 544,64,16,16
+	disabled-3: 560,64,16,16
+	disabled-4: 576,64,16,16
+	disabled-5: 592,64,16,16
+	disabled-6: 608,64,16,16
+	disabled-7: 624,64,16,16
+	disabled-8: 640,64,16,16
+	disabled-9: 656,64,16,16
+	disabled-10: 672,64,16,16
+	disabled-11: 688,64,16,16
+
 flags: buttons.png
 	america: 00, 00, 45, 21
 	germany: 00, 21, 45, 21

--- a/mods/ra2/mod.yaml
+++ b/mods/ra2/mod.yaml
@@ -122,6 +122,7 @@ ChromeLayout:
 	common|chrome/ingame-infobriefing.yaml
 	common|chrome/ingame-debug.yaml
 	common|chrome/ingame-perf.yaml
+	common|chrome/ingame-infochat.yaml
 	common|chrome/mainmenu.yaml
 	common|chrome/settings.yaml
 	common|chrome/credits.yaml
@@ -130,8 +131,10 @@ ChromeLayout:
 	common|chrome/lobby-options.yaml
 	common|chrome/lobby-music.yaml
 	common|chrome/lobby-mappreview.yaml
+	common|chrome/lobby-servers.yaml
 	common|chrome/lobby-kickdialogs.yaml
 	common|chrome/multiplayer-browser.yaml
+	common|chrome/multiplayer-browserpanels.yaml
 	common|chrome/multiplayer-createserver.yaml
 	common|chrome/multiplayer-directconnect.yaml
 	common|chrome/map-chooser.yaml


### PR DESCRIPTION
Fixes the following crashes and thus makes ra2 multiplayer playable again.

> Cannot find widget with Id `MULTIPLAYER_FILTER_PANEL`

> Sprite reload-icon/disabled-1 was not found.

> Cannot find widget with Id `LOBBY_SERVERS_BIN`

> Cannot find widget with Id `CHAT_CONTAINER`