### PR TITLE
Change the unrestricted techlevel to provide the superweapons prereq

### DIFF
--- a/mods/ra2/rules/allied-structures.yaml
+++ b/mods/ra2/rules/allied-structures.yaml
@@ -837,7 +837,7 @@ gaweat:
 	Buildable:
 		Queue: Support
 		BuildPaletteOrder: 90
-		Prerequisites: gatech, ~structures.allies
+		Prerequisites: gatech, ~structures.allies, ~techlevel.superweapons
 		BuildLimit: 1
 		Description: Play God with deadly weather!
 	Selectable:
@@ -868,7 +868,7 @@ gacsph:
 	Buildable:
 		Queue: Support
 		BuildPaletteOrder: 80
-		Prerequisites: gatech, ~structures.allies
+		Prerequisites: gatech, ~structures.allies, ~techlevel.superweapons
 		Description: Allows teleporting units in a 3x3 array.
 		BuildLimit: 1
 	Selectable:

--- a/mods/ra2/rules/player.yaml
+++ b/mods/ra2/rules/player.yaml
@@ -74,7 +74,7 @@ Player:
 		Id: medium
 	ProvidesTechPrerequisite@unrestricted:
 		Name: Unrestricted
-		Prerequisites: techlevel.infonly, techlevel.low, techlevel.medium, techlevel.unrestricted
+		Prerequisites: techlevel.infonly, techlevel.low, techlevel.medium, techlevel.superweapons
 		Id: unrestricted
 	GrantConditionOnPrerequisiteManager:
 	VeteranProductionIconOverlay:

--- a/mods/ra2/rules/soviet-structures.yaml
+++ b/mods/ra2/rules/soviet-structures.yaml
@@ -686,7 +686,7 @@ nairon:
 	Buildable:
 		Queue: Support
 		BuildPaletteOrder: 80
-		Prerequisites: natech, ~structures.soviets
+		Prerequisites: natech, ~structures.soviets, ~techlevel.superweapons
 		BuildLimit: 1
 		Description: Grants invulnerability to armored units.\nFries fleshy units.
 	Valued:
@@ -730,7 +730,7 @@ namisl:
 	Buildable:
 		Queue: Support
 		BuildPaletteOrder: 90
-		Prerequisites: natech, ~structures.soviets
+		Prerequisites: natech, ~structures.soviets, ~techlevel.superweapons
 		BuildLimit: 1
 		Description: Provides an atomic bomb.\nRequires power to operate.\n  Special Ability: Atom Bomb\nMaximum 1 can be built.
 	Valued:


### PR DESCRIPTION
This essentially changes the **Medium** techlevel to "no superweapons."

Closes #469.