### PR TITLE
Some weapon and offset adjustments

### DIFF
--- a/mods/ra2/rules/allied-naval.yaml
+++ b/mods/ra2/rules/allied-naval.yaml
@@ -66,12 +66,12 @@ dest:
 		Bounds: 80, 80, 0, -6
 	Armament@primary:
 		Weapon: 155mm
-		LocalOffset: 768,0,0
+		LocalOffset: 1024,0,768
 		FireDelay: 2
 		RequiresCondition: !rank-elite
 	Armament@elite:
 		Weapon: 155mmE
-		LocalOffset: 768,0,0
+		LocalOffset: 1024,0,768
 		FireDelay: 2
 		RequiresCondition: rank-elite
 	AttackFrontal:

--- a/mods/ra2/rules/allied-structures.yaml
+++ b/mods/ra2/rules/allied-structures.yaml
@@ -716,7 +716,7 @@ gtgcan:
 		Recoil: 127
 		RecoilRecovery: 26
 		MuzzleSequence: muzzle
-		LocalOffset: 1300,0,900
+		LocalOffset: 1792,0,1280
 	BodyOrientation:
 		QuantizedFacings: 16
 	RenderVoxels:

--- a/mods/ra2/rules/allied-vehicles.yaml
+++ b/mods/ra2/rules/allied-vehicles.yaml
@@ -114,11 +114,11 @@ mtnk:
 		TurnSpeed: 5
 	Armament@primary:
 		Weapon: 105mm
-		LocalOffset: 640,0,384
+		LocalOffset: 640,0,512
 		RequiresCondition: !rank-elite
 	Armament@elite:
 		Weapon: 105mmE
-		LocalOffset: 640,0,384
+		LocalOffset: 640,0,512
 		RequiresCondition: rank-elite
 	AttackTurreted:
 		Voice: Attack
@@ -161,11 +161,11 @@ tnkd:
 		Range: 8c0
 	Armament@primary:
 		Weapon: sabot
-		LocalOffset: 640,0,384
+		LocalOffset: 704,0,768
 		RequiresCondition: !rank-elite
 	Armament@elite:
 		Weapon: sabotE
-		LocalOffset: 640,0,384
+		LocalOffset: 704,0,768
 		RequiresCondition: rank-elite
 	AttackFrontal:
 		Voice: Attack
@@ -229,11 +229,11 @@ fv:
 			cleg: ifv-chrono
 	Armament@primary:
 		Weapon: HoverMissile
-		LocalOffset: 640, 0, 384
+		LocalOffset: 128,-128,1024, 128,128,1024
 		RequiresCondition: !rank-elite && !ifv-mg && !ifv-repair && !ifv-sniper && !ifv-flak && !ifv-tesla && !ifv-deso && !ifv-demo && !ifv-hero && !ifv-chrono
 	Armament@elite:
 		Weapon: HoverMissileE
-		LocalOffset: 640, 0, 384
+		LocalOffset: 128,-128,1024, 128,128,1024
 		RequiresCondition: rank-elite && !ifv-mg && !ifv-repair && !ifv-sniper && !ifv-flak && !ifv-tesla && !ifv-deso && !ifv-demo && !ifv-hero && !ifv-chrono
 	Armament@mg:
 		Weapon: CRM60
@@ -354,11 +354,11 @@ sref:
 		Offset: -30,0,85
 	Armament@primary:
 		Weapon: Comet
-		LocalOffset: 640, 0, 427
+		LocalOffset: 240,0,1280
 		RequiresCondition: !rank-elite
 	Armament@elite:
 		Weapon: SuperComet
-		LocalOffset: 640, 0, 427
+		LocalOffset: 240,0,1280
 		RequiresCondition: rank-elite
 	AttackTurreted:
 		Voice: Attack
@@ -403,11 +403,11 @@ mgtk:
 		Range: 9c0
 	Armament@primary:
 		Weapon: MirageGun
-		LocalOffset: 640, 0, 427
+		LocalOffset: 640,0,640
 		RequiresCondition: !rank-elite
 	Armament@elite:
 		Weapon: MirageGunE
-		LocalOffset: 640, 0, 427
+		LocalOffset: 640,0,640
 		RequiresCondition: rank-elite
 	AttackFrontal:
 		Voice: Attack

--- a/mods/ra2/rules/soviet-infantry.yaml
+++ b/mods/ra2/rules/soviet-infantry.yaml
@@ -75,15 +75,19 @@ flakt:
 		Voice: Attack
 	Armament@primary:
 		Weapon: FlakGuyGun
+		LocalOffset: 256,0,1024
 		RequiresCondition: !rank-elite
 	Armament@secondary:
 		Weapon: FlakGuyAAGun
+		LocalOffset: 256,0,1024 
 		RequiresCondition: !rank-elite
 	Armament@primary-elite:
 		Weapon: FlakGuyGunE
+		LocalOffset: 256,0,1024
 		RequiresCondition: rank-elite
 	Armament@secondary-elite:
 		Weapon: FlakGuyAAGunE
+		LocalOffset: 256,0,1024
 		RequiresCondition: rank-elite
 	WithInfantryBody:
 		DefaultAttackSequence: shoot
@@ -135,7 +139,7 @@ shk:
 		RequiresCondition: rank-elite
 	Armament@charge:
 		Weapon: AssaultBolt
-		LocalOffset: 427,0,341
+		LocalOffset: 320,128,1024
 		TargetStances: Ally
 		ForceTargetStances: None
 		Cursor: ability

--- a/mods/ra2/rules/soviet-naval.yaml
+++ b/mods/ra2/rules/soviet-naval.yaml
@@ -129,8 +129,10 @@ hyd:
 		Voice: Attack
 	Armament@primary:
 		Weapon: FlakTrackGun
+		LocalOffset: 256,0,1408
 	Armament@secondary:
 		Weapon: FlakWeapon
+		LocalOffset: 256,0,1408
 	Explodes:
 		Weapon: UnitExplode
 		EmptyWeapon: UnitExplode

--- a/mods/ra2/rules/soviet-structures.yaml
+++ b/mods/ra2/rules/soviet-structures.yaml
@@ -861,11 +861,11 @@ tesla:
 	WithTeslaChargeOverlay:
 	Armament:
 		Weapon: CoilBolt
-		LocalOffset: 0,0,2200
+		LocalOffset: 0,0,3072
 		RequiresCondition: !charged
 	Armament@charged:
 		Weapon: OPCoilBolt
-		LocalOffset: 0,0,2200
+		LocalOffset: 0,0,3072
 		RequiresCondition: charged
 	AttackTesla:
 		Voice: Attack

--- a/mods/ra2/rules/soviet-vehicles.yaml
+++ b/mods/ra2/rules/soviet-vehicles.yaml
@@ -69,11 +69,11 @@ harv:
 		Type: Medium
 	Armament@primary:
 		Weapon: 20mmrapid
-		LocalOffset: 0,50,384, 0,-50,384
+		LocalOffset: 256,0,1024
 		RequiresCondition: !rank-elite
 	Armament@elite:
 		Weapon: 20mmrapidE
-		LocalOffset: 0,50,384, 0,-50,384
+		LocalOffset: 256,0,1024
 		RequiresCondition: rank-elite
 	AttackTurreted:
 		Voice: Attack
@@ -269,15 +269,15 @@ apoc:
 		TurnSpeed: 5
 	Armament@primary:
 		Weapon: 120mmx
-		LocalOffset: 640,0,384
+		LocalOffset: 640,100,512, 640,-100,512
 		RequiresCondition: !rank-elite
 	Armament@elite:
 		Weapon: 120mmxE
-		LocalOffset: 640,0,384
+		LocalOffset: 640,100,512, 640,-100,512
 		RequiresCondition: rank-elite
 	Armament@antiair:
 		Weapon: MammothTusk
-		LocalOffset: 640,0,384
+		LocalOffset: 80,200,768, 80,-200,768
 	AttackTurreted:
 		Voice: Attack
 	AutoTarget:
@@ -320,11 +320,11 @@ ttnk:
 		TurnSpeed: 5
 	Armament@primary:
 		Weapon: TankBolt
-		LocalOffset: 280,196,384, 280,-196,384
+		LocalOffset: 280,196,640, 280,-196,640
 		RequiresCondition: !rank-elite
 	Armament@elite:
 		Weapon: TankBoltE
-		LocalOffset: 280,196,384, 280,-196,384
+		LocalOffset: 280,196,640, 280,-196,640
 		RequiresCondition: rank-elite
 	AttackTurreted:
 		Voice: Attack

--- a/mods/ra2/weapons/bullets.yaml
+++ b/mods/ra2/weapons/bullets.yaml
@@ -31,7 +31,7 @@ sabot:
 	ReloadDelay: 70
 	Report: vtadatta.wav, vtadattb.wav, vtadattc.wav
 	Projectile: Bullet
-		Speed: 100c0
+		Speed: 682
 	Warhead@1Dam: SpreadDamage
 		Spread: 190
 		Damage: 150
@@ -53,6 +53,9 @@ sabotE:
 	Inherits: sabot
 	Range: 6c768
 	ReloadDelay: 60
+	Projectile: Bullet
+		Blockable: false
+		Speed: 682
 	Warhead@1Dam: SpreadDamage
 		Damage: 175
 		Versus:
@@ -141,6 +144,8 @@ MirageGunE:
 	ReloadDelay: 60
 	Range: 5c0
 	Report: vgriatta.wav, vgriattb.wav, vgriattc.wav
+	Projectile: Bullet
+		Speed: 682
 	Warhead@1Dam: SpreadDamage
 		Damage: 65
 		Versus:
@@ -161,6 +166,8 @@ MirageGunE:
 	ReloadDelay: 75
 	Burst: 2
 	BurstDelays: 5
+	Projectile: Bullet
+		Speed: 682
 	Warhead@1Dam: SpreadDamage
 		Damage: 55
 		Versus:
@@ -180,6 +187,8 @@ MirageGunE:
 	ReloadDelay: 65
 	Range: 5c768
 	Report: vrhiatta.wav, vrhiattb.wav, vrhiattc.wav, vrhiattd.wav
+	Projectile: Bullet
+		Speed: 682
 	Warhead@1Dam: SpreadDamage
 		Damage: 90
 		Versus:
@@ -200,6 +209,8 @@ MirageGunE:
 	ReloadDelay: 80
 	Burst: 2
 	BurstDelays: 5
+	Projectile: Bullet
+		Speed: 682
 	Warhead@1Dam: SpreadDamage
 		Damage: 85
 		Versus:
@@ -221,6 +232,8 @@ MirageGunE:
 	Inherits: 120mm
 	Report: vapoat1a.wav
 	Burst: 2
+	Projectile: Bullet
+		Speed: 682
 	Warhead@1Dam: SpreadDamage
 		Damage: 100
 		Versus:
@@ -235,6 +248,8 @@ MirageGunE:
 	Inherits: 120mmx
 	Burst: 4
 	BurstDelays: 5
+	Projectile: Bullet
+		Speed: 682
 	Warhead@1Dam: SpreadDamage
 		Versus:
 			None: 100
@@ -253,6 +268,9 @@ MirageGunE:
 	ReloadDelay: 110
 	Range: 8c0
 	Report: vdesatta.wav, vrdesattb.wav
+	Projectile: Bullet
+		Blockable: false
+		Speed: 682
 	Warhead@1Dam: SpreadDamage
 		Damage: 60
 		Versus:

--- a/mods/ra2/weapons/defaults.yaml
+++ b/mods/ra2/weapons/defaults.yaml
@@ -3,7 +3,9 @@
 	Range: 5c0
 	Report: vflaat1a.wav, vflaat1b.wav
 	Projectile: Bullet
-		Speed: 50c0
+		Image: 120mm
+		LaunchAngle: 128
+		Speed: 341
 	Warhead@1Dam: SpreadDamage
 		Spread: 64
 		Damage: 20
@@ -31,8 +33,8 @@
 ^AAFlak:
 	Inherits: ^Flak
 	Report: vflaat2a.wav, vflaat2b.wav, vflaat2c.wav, vflaat2d.wav
-	Projectile: Bullet
-		Speed: 100c0
+	-Projectile: Bullet
+	Projectile: InstantHit
 	Warhead@1Dam: SpreadDamage
 		Spread: 120
 		ValidTargets: Air
@@ -114,8 +116,8 @@
 	ReloadDelay: 20
 	Range: 4c0
 	Report: igiat1a.wav, igiat1b.wav, igiat1c.wav
-	Projectile: Bullet
-		Speed: 100c0
+	Projectile: InstantHit
+		Blockable: true
 	Warhead@1Dam: SpreadDamage
 		Spread: 64
 		Damage: 20


### PR DESCRIPTION
Makes AG Flak and Tank Cannons weapons with slower visible projectiles.

Adjustes a lot of units' firing offsets.

Makes MG and AA Flak weapons actually instant hit instead of fast bullet weapons.