### PR TITLE
Adjust movement speed values

### DIFF
--- a/mods/ra2/rules/aircraft.yaml
+++ b/mods/ra2/rules/aircraft.yaml
@@ -32,7 +32,7 @@ shad:
 		LandWhenIdle: true
 		LandableTerrainTypes: Clear, Rough, Road, DirtRoad, Ore, Gems
 		TurnSpeed: 10
-		Speed: 100
+		Speed: 140
 		AltitudeVelocity: 120
 		CruisingCondition: cruising
 	RenderSprites:
@@ -56,7 +56,7 @@ shadhusk:
 		Name: Night Hawk
 	Aircraft:
 		TurnSpeed: 10
-		Speed: 100
+		Speed: 140
 	RevealsShroud:
 		Range: 7c0
 		Type: CenterPosition
@@ -81,7 +81,7 @@ zep:
 	Aircraft:
 		CruiseAltitude: 5600
 		TurnSpeed: 5
-		Speed: 50
+		Speed: 25
 		Voice: Move
 		AirborneCondition: airborne
 		CanHover: True
@@ -120,7 +120,7 @@ zephusk:
 		Name: Kirov Airship
 	Aircraft:
 		TurnSpeed: 5
-		Speed: 50
+		Speed: 25
 	FallsToEarth:
 		Spins: False # TODO: In the original they did spin, but that just looks weird.
 	RevealsShroud:
@@ -144,7 +144,7 @@ orca:
 		Description: Fast assault fighter\n  Strong vs Buildings, Vehicles\n  Weak vs Infantry, Aircraft
 	Aircraft:
 		TurnSpeed: 3
-		Speed: 140
+		Speed: 210
 		RearmBuildings: gaairc, amradr
 	Selectable:
 		Bounds: 30,24
@@ -184,7 +184,7 @@ orcahusk:
 		Name: Harrier
 	Aircraft:
 		TurnSpeed: 5
-		Speed: 140
+		Speed: 210
 	RenderVoxels:
 		Image: falc
 
@@ -215,7 +215,7 @@ beaghusk:
 		Name: Black Eagle
 	Aircraft:
 		TurnSpeed: 5
-		Speed: 140
+		Speed: 210
 	RenderVoxels:
 		Image: beag
 
@@ -230,7 +230,7 @@ pdplane:
 	Aircraft:
 		CruiseAltitude: 5600
 		TurnSpeed: 5
-		Speed: 100
+		Speed: 225
 	Health:
 		HP: 1000
 	RevealsShroud:

--- a/mods/ra2/rules/allied-infantry.yaml
+++ b/mods/ra2/rules/allied-infantry.yaml
@@ -18,8 +18,6 @@ engineer:
 		Bounds: 20, 30, 0, -11
 	Health:
 		HP: 75
-	Mobile:
-		Speed: 56
 	Passenger:
 		PipType: Blue
 	EngineerRepair:
@@ -61,7 +59,7 @@ dog:
 	Health:
 		HP: 100
 	Mobile:
-		Speed: 99
+		Speed: 120
 	Passenger:
 		PipType: Yellow
 	RevealsShroud:
@@ -124,7 +122,6 @@ e1:
 	Health:
 		HP: 125
 	Mobile:
-		Speed: 31
 	Passenger:
 		PipType: Green
 	RevealsShroud:
@@ -173,8 +170,6 @@ snipe:
 		Description: Special anti-infantry unit.\n  Strong vs Infantry\n  Weak vs Vehicles, Aircraft
 	Selectable:
 		Bounds: 20, 30, 0, -11
-	Mobile:
-		Speed: 35
 	Health:
 		HP: 125
 	Passenger:
@@ -215,8 +210,6 @@ spy:
 		Bounds: 24, 28, -1, -8
 	Health:
 		HP: 25
-	Mobile:
-		Speed: 56
 	RevealsShroud:
 		Range: 5c0
 	Passenger:
@@ -270,7 +263,7 @@ ghost:
 	Health:
 		HP: 125
 	Mobile:
-		Speed: 71
+		Speed: 75
 		Locomotor: swimsuit
 	RevealsShroud:
 		Range: 8c0
@@ -408,7 +401,7 @@ tany:
 	Health:
 		HP: 125
 	Mobile:
-		Speed: 71
+		Speed: 75
 		Locomotor: swimsuit
 	RevealsShroud:
 		Range: 6c0
@@ -476,8 +469,8 @@ jumpjet:
 		CruiseAltitude: 3072
 		LandWhenIdle: false
 		InitialFacing: 20
-		TurnSpeed: 10
-		Speed: 100
+		TurnSpeed: 255
+		Speed: 140
 		AltitudeVelocity: 83
 		Voice: Move
 		AirborneCondition: airborne
@@ -526,7 +519,7 @@ jumpjet.husk:
 		Name: Rocketeer
 	Aircraft:
 		TurnSpeed: 10
-		Speed: 100
+		Speed: 140
 	FallsToEarth:
 		Explosion: UnitExplodeSmall
 	RevealsShroud:

--- a/mods/ra2/rules/allied-naval.yaml
+++ b/mods/ra2/rules/allied-naval.yaml
@@ -17,8 +17,8 @@ lcrf:
 	Armor:
 		Type: Light
 	Mobile:
-		TurnSpeed: 10
-		Speed: 75
+		TurnSpeed: 5
+		Speed: 90
 		Locomotor: lcraft
 		RequiresCondition: !notmobile && !chronodisable
 	RevealsShroud:
@@ -59,7 +59,7 @@ dest:
 		Type: Heavy
 	Mobile:
 		TurnSpeed: 5
-		Speed: 105
+		Speed: 90
 	RevealsShroud:
 		Range: 7c0
 	Selectable:
@@ -109,8 +109,8 @@ aegis:
 	Armor:
 		Type: Light
 	Mobile:
-		TurnSpeed: 5
-		Speed: 45
+		TurnSpeed: 1
+		Speed: 60
 	RevealsShroud:
 		Range: 8c0
 	Armament:
@@ -148,7 +148,7 @@ dlph:
 		HP: 200
 	Mobile:
 		TurnSpeed: 6
-		Speed: 90
+		Speed: 120
 		Locomotor: naval
 		Voice: Move
 	SelectionDecorations:

--- a/mods/ra2/rules/allied-vehicles.yaml
+++ b/mods/ra2/rules/allied-vehicles.yaml
@@ -18,7 +18,7 @@ amcv:
 	Armor:
 		Type: Heavy
 	Mobile:
-		Speed: 80
+		Speed: 60
 		TurnSpeed: 5
 		Locomotor: heavytracked
 	RevealsShroud:
@@ -71,7 +71,7 @@ cmin:
 	Armor:
 		Type: Medium
 	Mobile:
-		Speed: 85
+		Speed: 60
 		TurnSpeed: 8
 		Locomotor: tracked
 	RevealsShroud:
@@ -101,7 +101,7 @@ mtnk:
 		Prerequisites: ~gaweap
 		Description: Allied Main Battle Tank.\n  Strong vs Vehicles, Ships\n  Weak vs Infantry, Aircraft
 	Mobile:
-		Speed: 90
+		Speed: 105
 		TurnSpeed: 5
 		Locomotor: heavytracked
 	Health:
@@ -150,7 +150,7 @@ tnkd:
 		Prerequisites: ~vehicles.germany
 		Description: Special anti-armor unit.\n  Strong vs Vehicles, Ships\n  Weak vs Infantry, Aircraft
 	Mobile:
-		Speed: 70
+		Speed: 75
 		TurnSpeed: 5
 		Locomotor: heavytracked
 	Health:
@@ -196,7 +196,7 @@ fv:
 		Prerequisites: ~gaweap
 		Description: Multi-Purpose Vehicle.\nWithout passenger:\n  Strong vs Infantry, Aircraft\n  Weak vs Vehicles, Ships\nSpecial Ability: Armament depends on passenger.
 	Mobile:
-		Speed: 128
+		Speed: 150
 		TurnSpeed: 5
 		RequiresCondition: !notmobile && !chronodisable
 	Health:
@@ -344,7 +344,7 @@ sref:
 	Armor:
 		Type: Heavy
 	Mobile:
-		TurnSpeed: 6
+		TurnSpeed: 5
 		Speed: 60
 		Locomotor: heavytracked
 	RevealsShroud:

--- a/mods/ra2/rules/defaults.yaml
+++ b/mods/ra2/rules/defaults.yaml
@@ -558,6 +558,7 @@
 	RevealsShroud:
 		Range: 4c0
 	Mobile:
+		Speed: 60
 		Voice: Move
 		Locomotor: foot
 	WithTextControlGroupDecoration:

--- a/mods/ra2/rules/soviet-infantry.yaml
+++ b/mods/ra2/rules/soviet-infantry.yaml
@@ -20,8 +20,6 @@ e2:
 		Bounds: 20, 30, 0, -11
 	Health:
 		HP: 125
-	Mobile:
-		Speed: 34
 	Passenger:
 		PipType: Green
 	RevealsShroud:
@@ -65,8 +63,6 @@ flakt:
 		Bounds: 20, 30, 0, -11
 	Health:
 		HP: 100
-	Mobile:
-		Speed: 34
 	Passenger:
 		PipType: Green
 	RevealsShroud:
@@ -117,8 +113,6 @@ shk:
 		Bounds: 20, 30, 0, -11
 	Health:
 		HP: 130
-	Mobile:
-		Speed: 51
 	RevealsShroud:
 		Range: 6c0
 	Armor:
@@ -177,7 +171,7 @@ terror:
 	Health:
 		HP: 75
 	Mobile:
-		Speed: 71
+		Speed: 90
 	RevealsShroud:
 		Range: 6c0
 	Armor:
@@ -220,8 +214,6 @@ deso:
 		Bounds: 20, 30, 0, -11
 	Health:
 		HP: 150
-	Mobile:
-		Speed: 41
 	RevealsShroud:
 		Range: 6c0
 	Armor:
@@ -268,8 +260,6 @@ ivan:
 		VoiceSet: CrazyIvanVoice
 	Health:
 		HP: 125
-	Mobile:
-		Speed: 60
 	RevealsShroud:
 		Range: 6c0
 	Armor:
@@ -343,7 +333,6 @@ yuri:
 	Health:
 		HP: 100
 	Mobile:
-		Speed: 60
 		RequiresCondition: !deployed && !deploying && !chronodisable
 	RevealsShroud:
 		Range: 12c0
@@ -412,6 +401,8 @@ yuripr:
 		HP: 200
 	Armor:
 		Type: Flak
+	Mobile:
+		Speed: 90
 	RevealsShroud:
 		Range: 8c0
 	Armament:

--- a/mods/ra2/rules/soviet-naval.yaml
+++ b/mods/ra2/rules/soviet-naval.yaml
@@ -17,8 +17,8 @@ sapc:
 	Armor:
 		Type: Heavy
 	Mobile:
-		TurnSpeed: 10
-		Speed: 75
+		TurnSpeed: 5
+		Speed: 90
 		Locomotor: lcraft
 		RequiresCondition: !notmobile && !chronodisable
 	RevealsShroud:
@@ -56,8 +56,8 @@ sub:
 	Armor:
 		Type: Heavy
 	Mobile:
-		TurnSpeed: 4
-		Speed: 71
+		TurnSpeed: 2
+		Speed: 60
 	-LeavesTrails:
 	RevealsShroud:
 		Range: 6c0
@@ -122,7 +122,7 @@ hyd:
 		Type: Heavy
 	Mobile:
 		TurnSpeed: 6
-		Speed: 75
+		Speed: 120
 	RevealsShroud:
 		Range: 8c0
 	AttackFrontal:
@@ -159,7 +159,7 @@ sqd:
 	SelfHealing:
 	Mobile:
 		TurnSpeed: 6
-		Speed: 90
+		Speed: 120
 		Locomotor: naval
 		Voice: Move
 	SelectionDecorations:

--- a/mods/ra2/rules/soviet-vehicles.yaml
+++ b/mods/ra2/rules/soviet-vehicles.yaml
@@ -18,8 +18,8 @@ smcv:
 	Armor:
 		Type: Heavy
 	Mobile:
-		Speed: 85
-		TurnSpeed: 8
+		Speed: 60
+		TurnSpeed: 5
 		Locomotor: heavytracked
 	RevealsShroud:
 		Range: 4c0
@@ -82,7 +82,7 @@ harv:
 		TurnSpeed: 10
 		Offset: 196,0,-24
 	Mobile:
-		Speed: 85
+		Speed: 60
 		TurnSpeed: 8
 		Locomotor: tracked
 	RevealsShroud:
@@ -110,7 +110,7 @@ dron:
 		Prerequisites: ~naweap
 		Description: \n  Strong vs Infantry, Vehicles\n  Weak vs Aircraft
 	Mobile:
-		Speed: 105
+		Speed: 150
 		TurnSpeed: 15
 	Health:
 		HP: 100
@@ -154,8 +154,8 @@ htk:
 		Prerequisites: ~naweap
 		Description: Infantry Transport and Anti-Air/Anti-Infantry vehicle.\n  Strong vs Aircraft, Infantry\n  Weak vs Vehicles
 	Mobile:
-		Speed: 75
-		TurnSpeed: 15
+		Speed: 120
+		TurnSpeed: 5
 		Locomotor: tracked
 		RequiresCondition: !notmobile && !chronodisable
 	Health:
@@ -206,7 +206,7 @@ htnk:
 		Prerequisites: ~naweap
 		Description: Soviet Main Battle Tank.\n  Strong vs Vehicles\n  Weak vs Infantry, Aircraft
 	Mobile:
-		Speed: 75
+		Speed: 90
 		TurnSpeed: 5
 		Locomotor: heavytracked
 	Health:
@@ -256,7 +256,7 @@ apoc:
 		Prerequisites: ~naweap, natech
 		Description: Soviet Advanced Battle Tank with Double Barrel\nand Anti-Aircraft Missile Launcher.\n  Strong vs Vehicles, Aircraft\n  Weak vs Infantry
 	Mobile:
-		Speed: 45
+		Speed: 60
 		TurnSpeed: 5
 		Locomotor: heavytracked
 	Health:
@@ -360,8 +360,8 @@ dtruck:
 	Armor:
 		Type: Light
 	Mobile:
-		Speed: 85
-		TurnSpeed: 8
+		Speed: 75
+		TurnSpeed: 5
 		Locomotor: heavytracked
 	RevealsShroud:
 		Range: 4c0


### PR DESCRIPTION
This makes units use 15x the original Speed value, for jumpjet units (Rockeeter, Nighthawk, Kirov) it is 15/3,25x times their JumpjetSpeed value.

15x is a value we found that seems good, we didn't do much calculation.

To find the 3,25, i did some tests with demo truck and kirov (have Speed and JumpjetSpeed of 5 respectively) and it took Kirov 3,25 times more to take the same path.