### PR TITLE
Fix Short Game mode

### DIFF
--- a/mods/ra2/rules/defaults.yaml
+++ b/mods/ra2/rules/defaults.yaml
@@ -614,7 +614,6 @@
 		Voice: Melted
 		DeathTypes: RadiationDeath
 	MustBeDestroyed:
-		RequiredForShortGame: true
 	Cloneable:
 		Types: infantry
 	Voiced:
@@ -705,8 +704,7 @@
 	ProximityCaptor:
 		Types: CivilianInfantry
 	ScaredyCat:
-	MustBeDestroyed:
-		RequiredForShortGame: true
+	-MustBeDestroyed:
 	-TakeCover:
 	Voiced:
 		VoiceSet: CivilianAlliedMaleVoice
@@ -805,7 +803,6 @@
 		LightAmbientColor: -0.5,-0.5,-0.5
 		LightDiffuseColor: 1.4,1.4,1.4
 	MustBeDestroyed:
-		RequiredForShortGame: true
 	Voiced:
 		VoiceSet: AlliedVehicleVoice
 	Chronoshiftable:
@@ -988,7 +985,6 @@
 		LightAmbientColor: -0.5,-0.5,-0.5
 		LightDiffuseColor: 1.4,1.4,1.4
 	MustBeDestroyed:
-		RequiredForShortGame: true
 	Voiced:
 		VoiceSet: SovietNavalVoice
 	Chronoshiftable:


### PR DESCRIPTION
Seems like everyone had RequiredForShortGame: true instead of just buildings and MCV (already overrides it to true, didn't have to edit them).