### PR TITLE
Give ships water target type

### DIFF
--- a/mods/ra2/rules/defaults.yaml
+++ b/mods/ra2/rules/defaults.yaml
@@ -962,7 +962,7 @@
 	Selectable:
 		Bounds: 32,32
 	Targetable:
-		TargetTypes: Ground, Repair
+		TargetTypes: Ground, Water, Repair
 	Repairable:
 		Voice: Attack
 		RepairBuildings: gayard, nayard


### PR DESCRIPTION
Lack of water target type was causing Typhoons to be unable to attack the ships.