### PR TITLE
Give Squid self heal some values

### DIFF
--- a/mods/ra2/rules/soviet-naval.yaml
+++ b/mods/ra2/rules/soviet-naval.yaml
@@ -157,6 +157,9 @@ sqd:
 	Health:
 		HP: 200
 	SelfHealing:
+		Step: 2
+		Delay: 100
+		DamageCooldown: 125
 	Mobile:
 		TurnSpeed: 6
 		Speed: 120


### PR DESCRIPTION
Default values are making it heal in almost instant speed. This values aren't original, tho better than having insta heal squids.