### PR TITLE
Make some infantry uncrushable as in original.

### DIFF
--- a/mods/ra2/rules/allied-infantry.yaml
+++ b/mods/ra2/rules/allied-infantry.yaml
@@ -310,6 +310,7 @@ ccomand:
 		HP: 100
 	Mobile:
 		Locomotor: foot
+	-Crushable:
 	PortableChrono:
 		ChronoshiftSound: ichrmova.wav
 		DeployCursor: chronosphere

--- a/mods/ra2/rules/allied-infantry.yaml
+++ b/mods/ra2/rules/allied-infantry.yaml
@@ -551,8 +551,6 @@ cleg:
 		Voice: Move
 	Health:
 		HP: 125
-	Mobile:
-		Speed: 51
 	RevealsShroud:
 		Range: 8c0
 	Passenger:

--- a/mods/ra2/rules/soviet-infantry.yaml
+++ b/mods/ra2/rules/soviet-infantry.yaml
@@ -121,6 +121,7 @@ shk:
 		Range: 6c0
 	Armor:
 		Type: Plate
+	-Crushable:
 	Passenger:
 		PipType: Red
 	AttackFrontal:
@@ -222,6 +223,7 @@ deso:
 		Range: 6c0
 	Armor:
 		Type: Plate
+	-Crushable:
 	Passenger:
 		PipType: Red
 	Armament@primary:
@@ -300,6 +302,7 @@ civan:
 		Name: Chrono Ivan
 	Valued:
 		Cost: 1000
+	-Crushable:
 	DeliversCash:
 		Payload: 500
 		PlayerExperience: 50
@@ -405,6 +408,7 @@ yuripr:
 		HP: 200
 	Armor:
 		Type: Flak
+	-Crushable:
 	Mobile:
 		Speed: 90
 	RevealsShroud:


### PR DESCRIPTION
Tesla Trooper, Desolator, Chrono Legionnarie and all the Spy Units seem to be uncrushable in original game. Seems like CLeg was already uncrushable here.

Also I noticed i missed Chrono Legionnarie's speed in the movement speeds PR so i removed it too (should use inherited value).