### PR TITLE
Fix civilians' name

### DIFF
--- a/mods/ra2/rules/civilians.yaml
+++ b/mods/ra2/rules/civilians.yaml
@@ -11,65 +11,45 @@ civ3:
 
 civa:
 	Inherits: ^CivilianInfantry
-	Tooltip:
-		Name: Texan
 	Voiced:
 		VoiceSet: CivilianTexanVoice
 
 civb:
 	Inherits: ^CivilianInfantry
-	Tooltip:
-		Name: Texan
 	Voiced:
 		VoiceSet: CivilianTexanVoice
 
 civc:
 	Inherits: ^CivilianInfantry
-	Tooltip:
-		Name: Texan
 	Voiced:
 		VoiceSet: CivilianTexanVoice
 
 civbbp:
 	Inherits: ^CivilianInfantry
-	Tooltip:
-		Name: Baseball Player
 
 civbfm:
 	Inherits: ^CivilianInfantry
-	Tooltip:
-		Name: Beach Fat Male
 
 civbf:
 	Inherits: ^CivilianInfantry
 	Voiced:
 		VoiceSet: CivilianAlliedFemaleVoice
-	Tooltip:
-		Name: Beach Fat Female
 
 civbtm:
 	Inherits: ^CivilianInfantry
-	Tooltip:
-		Name: Beach Thin Male
 
 civsfm:
 	Inherits: ^CivilianInfantry
-	Tooltip:
-		Name: Snow Fat Male
 	Voiced:
 		VoiceSet: CivilianSovietMaleVoice
 
 civsf:
 	Inherits: ^CivilianInfantry
-	Tooltip:
-		Name: Snow Fat Male
 	Voiced:
 		VoiceSet: CivilianSovietFemaleVoice
 
 civstm:
 	Inherits: ^CivilianInfantry
-	Tooltip:
-		Name: Snow Thin Male
 	Voiced:
 		VoiceSet: CivilianSovietMaleVoice
 

--- a/mods/ra2/rules/defaults.yaml
+++ b/mods/ra2/rules/defaults.yaml
@@ -693,7 +693,7 @@
 		PlayerExperience: 2
 		Voice: Move
 	Tooltip:
-		GenericName: Civilian
+		Name: Civilian
 	Health:
 		HP: 50
 	Mobile:


### PR DESCRIPTION
They were all called "Civilian" in original game. Those values are from the `Name=` field which isn't used ingame.

Closes https://github.com/OpenRA/ra2/issues/411.