### PR TITLE
Increase Amphibious Transport capacity.

### DIFF
--- a/mods/ra2/rules/allied-naval.yaml
+++ b/mods/ra2/rules/allied-naval.yaml
@@ -25,7 +25,7 @@ lcrf:
 		Range: 6c0
 	Cargo:
 		Types: Infantry, Vehicle
-		MaxWeight: 9
+		MaxWeight: 12
 		PipCount: 12
 		PassengerFacing: 96
 		UnloadTerrainTypes: Clear, Rough, Rail, Road, DirtRoad, Beach, Ore, Gems

--- a/mods/ra2/rules/soviet-naval.yaml
+++ b/mods/ra2/rules/soviet-naval.yaml
@@ -25,7 +25,7 @@ sapc:
 		Range: 6c0
 	Cargo:
 		Types: Infantry, Vehicle
-		MaxWeight: 9
+		MaxWeight: 12
 		PipCount: 12
 		PassengerFacing: 96
 		UnloadTerrainTypes: Clear, Rough, Rail, Road, DirtRoad, Beach, Ore, Gems


### PR DESCRIPTION
It should be 12, even PipCount was 12. I dunno who set it to 9.