### PR TITLE
Fix Tesla Coil charge sound

### DIFF
--- a/mods/ra2/rules/soviet-structures.yaml
+++ b/mods/ra2/rules/soviet-structures.yaml
@@ -875,7 +875,7 @@ tesla:
 		Voice: Attack
 		MaxCharges: 3
 		ReloadDelay: 120
-		ChargeAudio: tslachg2.aud
+		ChargeAudio: btespow.wav
 		PauseOnCondition: lowpower
 	AutoTarget:
 	GrantConditionOnPowerState@LOWPOWER:


### PR DESCRIPTION
It was still pointing at RA1 sound which of course doesn't play anything.