### PR TITLE
Fix crash when clicking tab on a cloning vats.

### DIFF
--- a/mods/ra2/rules/soviet-structures.yaml
+++ b/mods/ra2/rules/soviet-structures.yaml
@@ -651,7 +651,7 @@ naclon:
 		SpawnOffset: 0,0,0
 		ExitCell: 2, 2
 	Production:
-		Produces:
+		Produces: Dummy
 	RallyPoint:
 		Offset: 3,3
 		Palette: mouse


### PR DESCRIPTION
Leaving Produces empty crashes, but seems like giving it a dummy name don't.

Fixes #526.