### PR TITLE
Corrected exit positions for Airforce Command Headquarters

### DIFF
--- a/mods/ra2/rules/allied-structures.yaml
+++ b/mods/ra2/rules/allied-structures.yaml
@@ -280,17 +280,21 @@ gaairc:
 		Amount: -50
 	Reservable:
 	Exit@1:
-		SpawnOffset: -350,350,0
+		SpawnOffset: -370,370,0
 		MoveIntoWorld: false
+		Facing: 224
 	Exit@2:
-		SpawnOffset: 600,220,0
+		SpawnOffset: 370,-370,0
 		MoveIntoWorld: false
+		Facing: 224
 	Exit@3:
-		SpawnOffset: 200,820,0
+		SpawnOffset: 1000,370,0
 		MoveIntoWorld: false
+		Facing: 224
 	Exit@4:
-		SpawnOffset: 200,-300,0
+		SpawnOffset: 350,1000,0
 		MoveIntoWorld: false
+		Facing: 224
 	Production:
 		Produces: Aircraft
 	ProductionBar:


### PR DESCRIPTION
This corrects the positions of Harriers and Black Eagles when grounded mentioned in #495 

Before:
![2019-01-09 18_04_51-openra](https://user-images.githubusercontent.com/6731717/50916479-9069f580-143b-11e9-9a12-a91c7127fc5d.png)
After:
![2019-01-09 18_10_53-openra](https://user-images.githubusercontent.com/6731717/50916478-8fd15f00-143b-11e9-8e93-586511c03d92.png)
