### PR TITLE
Fix Tech Outpost Turret Color

### DIFF
--- a/mods/ra2/rules/tech-structures.yaml
+++ b/mods/ra2/rules/tech-structures.yaml
@@ -134,7 +134,11 @@ caoutp:
 		QuantizedFacings: 16
 		CameraPitch: 90
 	RenderVoxels:
-		NormalsPalette: ts-normals
+		Scale: 11.7
+		LightYaw: 800
+		LightPitch: 150
+		LightAmbientColor: -0.5,-0.5,-0.5
+		LightDiffuseColor: 1.4,1.4,1.4
 	WithVoxelTurret:
 	WithRangeCircle:
 		Range: 12c0


### PR DESCRIPTION
It was using the wrong normals and light values that everything else defines wasn't defined.