### PR TITLE
Use inheritance for sequences

### DIFF
--- a/mods/ra2/sequences/allied-structures.yaml
+++ b/mods/ra2/sequences/allied-structures.yaml
@@ -1,21 +1,12 @@
 gacnst:
+	Inherits: ^Structure
 	Defaults:
 		Offset: 3, -60
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: ggcnst
-		ShadowStart: 3
 	make: ggcnstmk
 		Length: 29
 		ShadowStart: 29
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 	damaged-idle: ggcnst
-		Start: 1
-		ShadowStart: 4
 	idle-fans: ggcnst_a
 		Length: 6
 		Tick: 150
@@ -35,21 +26,13 @@ gacnst:
 		ShadowStart: 30
 		Tick: 100
 	icon: acnsicon
-		Offset: 0,0
-		UseTilesetCode: false
 
 gapowr:
+	Inherits: ^Structure
 	Defaults:
 		Offset: 0, -31
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: ggpowr
-		ShadowStart: 3
 	damaged-idle: gtpowr
-		Start: 1
-		ShadowStart: 4
 	idle-glow: ggpowr_a
 		Length: 8
 		ShadowStart: 16
@@ -60,27 +43,14 @@ gapowr:
 		ShadowStart: 24
 		Tick: 150
 	make: gtpowrmk
-		Length: 25
-		ShadowStart: 25
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 	icon: powricon
-		Offset: 0,0
-		UseTilesetCode: false
 
 gapile:
+	Inherits: ^Structure
 	Defaults:
 		Offset: -15, -38
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: ggpile
-		ShadowStart: 3
 	damaged-idle: ggpile
-		Start: 1
-		ShadowStart: 4
 	idle-flag: ggpile_a
 		Length: 16
 		ShadowStart: 32
@@ -93,33 +63,15 @@ gapile:
 		ShadowStart: 25
 		Tick: 100
 	make: gtpilemk
-		Length: 25
-		ShadowStart: 25
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 	icon: brrkicon
-		Offset: 0,0
-		UseTilesetCode: false
 
 garefn:
+	Inherits: ^Structure
 	Defaults:
 		Offset: -12, -52
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: ggrefn
-		ShadowStart: 3
 	damaged-idle: ggrefn
-		Start: 1
-		ShadowStart: 4
 	make: gurefnmk
-		Length: 25
-		ShadowStart: 25
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 	idle-drill: ggrefnl1
 		Length: 6
 		Tick: 1500
@@ -134,20 +86,15 @@ garefn:
 		Length: 20
 		ShadowStart: 20
 	icon: reficon
-		Offset: 0,0
-		UseTilesetCode: false
 
 gaairc:
+	Inherits: ^Structure
 	Defaults:
 		Offset: -14, -38
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: ggairc
+		ShadowStart: -1
 		Length: 1
 	damaged-idle: ggairc
-		Start: 1
 		Length: 2
 	idle-top: gaairc_c
 		Length: 16
@@ -179,28 +126,15 @@ gaairc:
 		Tick: 120
 		ZOffset: -512
 	make: gtaircmk
-		Length: 25
-		ShadowStart: 25
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 	icon: heliicon
-		Offset: 0,0
-		UseTilesetCode: false
 
 gaweap:
+	Inherits: ^Structure
 	Defaults:
 		Offset: -30, -60
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: ggweap
-		ShadowStart: 3
 		ZOffset: -1024
 	damaged-idle: ggweap
-		Start: 1
-		ShadowStart: 4
 		ZOffset: -1024
 	build-ramp: ggweap_1
 		ShadowStart: 2
@@ -243,22 +177,12 @@ gaweap:
 		Length: 5
 		ShadowStart: 6
 	make: gtweapmk
-		Length: 25
-		ShadowStart: 25
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 	icon: gwepicon
-		Offset: 0,0
-		UseTilesetCode: false
 
 gayard:
+	Inherits: ^Structure
 	Defaults:
 		Offset: 0, -45
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: ggyard
 		ShadowStart: 4
 	damaged-idle: ggyard
@@ -283,11 +207,6 @@ gayard:
 		ShadowStart: 30
 		Tick: 200
 	make: gtyardmk
-		Length: 25
-		ShadowStart: 25
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 	repair: ggyard_s
 		Length: 18
 		ShadowStart: 36
@@ -296,20 +215,14 @@ gayard:
 		Length: 18
 		ShadowStart: 54
 	icon: ayaricon
-		Offset: 0,0
-		UseTilesetCode: false
 
 gadept:
+	Inherits: ^Structure
 	Defaults:
 		Offset: 7, -40
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: ggdept_d
 		ShadowStart: 2
 	damaged-idle: ggdept_d
-		Start: 1
 		ShadowStart: 3
 	idle-side: ggdept
 		ShadowStart: 3
@@ -321,11 +234,6 @@ gadept:
 		ShadowStart: 3
 		ZOffset: -512
 	make: gtdeptmk
-		Length: 25
-		ShadowStart: 25
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 	repair: ggdept_c
 		Length: 10
 		ShadowStart: 20
@@ -336,21 +244,13 @@ gadept:
 		ShadowStart: 30
 		Tick: 180
 	icon: fixicon
-		Offset: 0,0
-		UseTilesetCode: false
 
 gatech:
+	Inherits: ^Structure
 	Defaults:
 		Offset: -15, -40
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: ggtech
-		ShadowStart: 3
 	damaged-idle: ggtech
-		Start: 1
-		ShadowStart: 4
 	idle-lights: ggtech_a
 		Length: 12
 		ShadowStart: 24
@@ -359,27 +259,14 @@ gatech:
 		Length: 12
 		ShadowStart: 36
 	make: gttechmk
-		Length: 25
-		ShadowStart: 25
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 	icon: techicon
-		Offset: 0,0
-		UseTilesetCode: false
 
 gaorep:
+	Inherits: ^Structure
 	Defaults:
 		Offset: 0, -45
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: ggorep
-		ShadowStart: 3
 	damaged-idle: ggorep
-		Start: 1
-		ShadowStart: 4
 	idle-glow: ggorep_a
 		Length: 8
 		ShadowStart: 16
@@ -390,19 +277,14 @@ gaorep:
 		ShadowStart: 24
 		Tick: 180
 	make: gtorepmk
-		Length: 25
-		ShadowStart: 25
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 	icon: gorep
-		Offset: 0,0
-		UseTilesetCode: false
 
 gawall:
+	Inherits: ^Structure
 	Defaults:
 		Offset: 0, -12
-		UseTilesetCode: true
+		-TilesetOverrides:
+	-make:
 	idle: gtwall
 		Length: 16
 		ShadowStart: 48
@@ -415,21 +297,13 @@ gawall:
 		Length: 16
 		ShadowStart: 80
 	icon: wallicon
-		Offset: 0,0
-		UseTilesetCode: false
 
 gapill:
+	Inherits: ^Structure
 	Defaults:
 		Offset: 0, -15
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: ggpill
-		ShadowStart: 3
 	damaged-idle: ggpill
-		Start: 1
-		ShadowStart: 4
 	critical-idle: ggpill
 		Start: 2
 		ShadowStart: 5
@@ -460,53 +334,31 @@ gapill:
 	make: gtpillmk
 		Length: 8
 		ShadowStart: 8
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 	icon: pillicon
-		Offset: 0,0
-		UseTilesetCode: false
 
 nasam:
+	Inherits: ^Structure
 	Defaults:
 		Offset: 0, -15
 		ZOffset: -512
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: ngsam
-		ShadowStart: 3
 	damaged-idle: ngsam
-		Start: 1
-		ShadowStart: 4
 	critical-idle: ngsam
 		Start: 2
 		ShadowStart: 5
 	make: ntsammk
 		Length: 8
 		ShadowStart: 8
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 		ZOffset: 0
 	icon: samicon
-		Offset: 0,0
-		UseTilesetCode: false
 
 gtgcan:
+	Inherits: ^Structure
 	Defaults:
 		Offset: 0, -30
 		ZOffset: -512
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: gggcan
-		ShadowStart: 3
 	damaged-idle: gggcan
-		Start: 1
-		ShadowStart: 4
 	critical-idle: gggcan
 		Start: 2
 		ShadowStart: 5
@@ -514,31 +366,20 @@ gtgcan:
 	make: gtgcanmk
 		Length: 12
 		ShadowStart: 12
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 		ZOffset: 0
 	muzzle: gcmuzzle
 		Length: *
 		Offset: 0,0
 		UseTilesetCode: false
 	icon: gcanicon
-		Offset: 0,0
-		UseTilesetCode: false
 
 gaspysat:
+	Inherits: ^Structure
 	Defaults:
 		Offset: 0, -31
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: ggspst
-		ShadowStart: 3
 		Tick: 180
 	damaged-idle: ggspst
-		Start: 1
-		ShadowStart: 4
 		Tick: 180
 	idle-dish: ggspst_a
 		Length: 16
@@ -548,75 +389,40 @@ gaspysat:
 		Length: 16
 		Tick: 180
 	make: gtspstmk
-		Length: 25
-		ShadowStart: 25
 		Tick: 90
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 	icon: asaticon
-		Offset: 0,0
-		UseTilesetCode: false
 
 gagap:
+	Inherits: ^Structure
 	Defaults:
 		Offset: -15, -7
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: gggap
 		Length: 1
-		ShadowStart: 3
 	damaged-idle: gggap
 		Start: 2
 		Length: 1
-		ShadowStart: 4
 	make: gtgapmk
 		Length: 9
 		ShadowStart: 9
 		Tick: 90
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 	icon: gapicon
-		Offset: 0,0
-		UseTilesetCode: false
 
 gaweat:
+	Inherits: ^Structure
 	Defaults:
 		Offset: 0, -45
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: ggweth
-		ShadowStart: 3
 	damaged-idle: ggweth
-		Start: 1
-		ShadowStart: 4
 	make: guwethmk
-		Length: 25
-		ShadowStart: 25
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 	icon: wethicon
-		Offset: 0,0
-		UseTilesetCode: false
 
 gacsph:
+	Inherits: ^Structure
 	Defaults:
 		Offset: -15, -50
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: ggcsph
 		ShadowStart: 3
 	damaged-idle: ggcsph
-		Start: 1
-		ShadowStart: 4
 	idle-dome: ggcsph_e
 		ShadowStart: 2
 	damaged-idle-dome: ggcsph_e
@@ -627,27 +433,15 @@ gacsph:
 		ShadowStart: 25
 		Tick: 50
 	make: gtcsphmk
-		Length: 25
-		ShadowStart: 25
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 	icon: csphicon
-		Offset: 0,0
-		UseTilesetCode: false
 
 atesla:
+	Inherits: ^Structure
 	Defaults:
 		Offset: 1,-15
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle-normal: ggpris
 		ShadowStart: 3
 	damaged-idle-normal: ggpris
-		Start: 1
-		ShadowStart: 4
 	idle: ggpris_b
 		Length: 9
 		Tick: 100
@@ -671,12 +465,7 @@ atesla:
 		ShadowStart: 21
 		Tick: 100
 	icon: prisicon
-		Offset: 0,0
-		UseTilesetCode: false
 	make: gtprismk
 		Length: 8
 		ShadowStart: 8
 		Tick: 160
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN

--- a/mods/ra2/sequences/animals.yaml
+++ b/mods/ra2/sequences/animals.yaml
@@ -1,113 +1,54 @@
 cow:
+	Inherits: ^Animal
 	stand:
-		Facings: 8
 		ShadowStart: 116
 	run:
-		Start: 8
-		Length: 6
-		Facings: 8
 		ShadowStart: 124
 		Tick: 120
 	idle1:
-		Start: 56
-		Length: 15
 		ShadowStart: 172
 		Tick: 100
 	idle2:
-		Start: 71
-		Length: 15
 		ShadowStart: 187
 		Tick: 100
 	die1:
-		Start: 86
-		Length: 15
 		ShadowStart: 202
 	die2:
-		Start: 101
-		Length: 15
 		ShadowStart: 217
-	icon: xxicon
 
 all:
+	Inherits: ^Animal
 	stand:
-		Facings: 8
 		ShadowStart: 164
 	run:
-		Start: 8
-		Length: 6
-		Facings: 8
 		ShadowStart: 172
 		Tick: 120
 	shoot:
 		Start: 116
 		Length: 6
 		Facings: 8
-	idle1:
-		Start: 56
-		Length: 15
-	idle2:
-		Start: 71
-		Length: 15
 	die1:
-		Start: 86
-		Length: 15
 		ShadowStart: 202
 	die2:
-		Start: 101
-		Length: 15
 		ShadowStart: 217
-	icon: xxicon
 
 polarb:
-	stand:
-		Facings: 8
+	Inherits: ^Animal
 	run:
-		Start: 8
-		Length: 6
-		Facings: 8
 		Tick: 120
 	shoot:
 		Start: 116
 		Length: 6
 		Facings: 8
-	idle1:
-		Start: 56
-		Length: 15
-	idle2:
-		Start: 71
-		Length: 15
-	die1:
-		Start: 86
-		Length: 15
-	die2:
-		Start: 101
-		Length: 15
-	icon: xxicon
 
 josh:
-	stand:
-		Facings: 8
+	Inherits: ^Animal
 	run:
-		Start: 8
-		Length: 6
-		Facings: 8
 		Tick: 120
 	shoot:
 		Start: 116
 		Length: 6
 		Facings: 8
-	idle1:
-		Start: 56
-		Length: 15
-	idle2:
-		Start: 71
-		Length: 15
-	die1:
-		Start: 86
-		Length: 15
-	die2:
-		Start: 101
-		Length: 15
 	die4: nukedie
 		Length: *
 		Tick: 50
@@ -117,4 +58,3 @@ josh:
 	die6: electro
 		Length: *
 		Tick: 80
-	icon: xxicon

--- a/mods/ra2/sequences/bridges.yaml
+++ b/mods/ra2/sequences/bridges.yaml
@@ -1,11 +1,3 @@
-^bridge:
-	Defaults:
-		ZOffset: -1c511
-		UseTilesetExtension: true
-		Start: 1
-		ZRamp: 1
-		Offset: 0, 0, 0.5
-
 lobrdb_a:
 	Inherits: ^bridge
 	idle: lobrdb10

--- a/mods/ra2/sequences/civilian-props.yaml
+++ b/mods/ra2/sequences/civilian-props.yaml
@@ -1,268 +1,153 @@
 hdstn01:
-	Defaults:
-		UseTilesetExtension: true
-	idle:
-		ShadowStart: 1
+	Inherits: ^Pole
 
 lt_gen01:
-	Defaults:
-		UseTilesetExtension: true
-	idle:
-		ShadowStart: 1
+	Inherits: ^Pole
 
 lt_gen02:
-	Defaults:
-		UseTilesetExtension: true
-	idle:
-		ShadowStart: 1
+	Inherits: ^Pole
 
 lt_gen03:
-	Defaults:
-		UseTilesetExtension: true
-	idle:
-		ShadowStart: 1
+	Inherits: ^Pole
 
 lt_gen04:
-	Defaults:
-		UseTilesetExtension: true
-	idle:
-		ShadowStart: 1
+	Inherits: ^Pole
 
 lt_sgn01:
-	Defaults:
-		UseTilesetExtension: true
-	idle:
-		ShadowStart: 1
+	Inherits: ^Pole
 
 lt_sgn02:
-	Defaults:
-		UseTilesetExtension: true
-	idle:
-		ShadowStart: 1
+	Inherits: ^Pole
 
 lt_sgn03:
-	Defaults:
-		UseTilesetExtension: true
-	idle:
-		ShadowStart: 1
+	Inherits: ^Pole
 
 lt_sgn04:
-	Defaults:
-		UseTilesetExtension: true
+	Inherits: ^Pole
 	idle:
+		ShadowStart: -1
 
 lt_eur01:
-	Defaults:
-		UseTilesetExtension: true
-	idle:
-		ShadowStart: 1
+	Inherits: ^Pole
 
 lt_eur02:
-	Defaults:
-		UseTilesetExtension: true
-	idle:
-		ShadowStart: 1
+	Inherits: ^Pole
 
 pole01:
-	Defaults:
-		UseTilesetExtension: true
-	idle:
-		ShadowStart: 1
+	Inherits: ^Pole
 
 pole02:
-	Defaults:
-		UseTilesetExtension: true
-	idle:
-		ShadowStart: 1
+	Inherits: ^Pole
 
 sign01:
-	Defaults:
-		UseTilesetExtension: true
-	idle:
-		ShadowStart: 1
+	Inherits: ^Pole
 
 sign02:
-	Defaults:
-		UseTilesetExtension: true
-	idle:
-		ShadowStart: 1
+	Inherits: ^Pole
 
 sign03:
-	Defaults:
-		UseTilesetExtension: true
+	Inherits: ^Pole
 	idle:
+		ShadowStart: -1
 
 sign04:
-	Defaults:
-		UseTilesetExtension: true
-	idle:
-		ShadowStart: 1
+	Inherits: ^Pole
 
 sign05:
-	Defaults:
-		UseTilesetExtension: true
-	idle:
-		ShadowStart: 1
+	Inherits: ^Pole
 
 sign06:
-	Defaults:
-		UseTilesetExtension: true
-	idle:
-		ShadowStart: 1
+	Inherits: ^Pole
 
 trff01:
-	Defaults:
-		UseTilesetExtension: true
-	idle:
-		ShadowStart: 1
+	Inherits: ^Pole
 
 camsc01:
-	Defaults:
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 3
+	Inherits: ^Prop
 
 camsc02:
-	Defaults:
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 3
+	Inherits: ^Prop
 
 camsc03:
-	Defaults:
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 3
+	Inherits: ^Prop
 
 camsc04:
-	Defaults:
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 3
+	Inherits: ^Prop
 
 camsc05:
-	Defaults:
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 3
+	Inherits: ^Prop
 
 camsc06:
-	Defaults:
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 3
+	Inherits: ^Prop
 	idle-fire: camsc06a
 		Length: 4
 		ShadowStart: 4
 		Tick: 80
 
 camsc11:
-	Defaults:
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 3
+	Inherits: ^Prop
 
 camsc12:
-	Defaults:
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 3
+	Inherits: ^Prop
 
 camsc13:
-	Defaults:
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 3
+	Inherits: ^Prop
 
 trff02:
-	Defaults:
-		UseTilesetExtension: true
-	idle:
-		ShadowStart: 1
+	Inherits: ^Pole
 
 trff03:
-	Defaults:
-		UseTilesetExtension: true
-	idle:
-		ShadowStart: 1
+	Inherits: ^Pole
 
 trff04:
-	Defaults:
-		UseTilesetExtension: true
-	idle:
-		ShadowStart: 1
+	Inherits: ^Pole
 
 camisc01:
-	Defaults:
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 3
+	Inherits: ^Prop
 
 camisc02:
-	Defaults:
-		UseTilesetCode: true
+	Inherits: ^Prop
 	idle:
+		ShadowStart: -1
 
 camisc03:
-	Defaults:
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 3
+	Inherits: ^Prop
 
 camisc04:
-	Defaults:
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 3
+	Inherits: ^Prop
 
 camisc05:
-	Defaults:
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 3
+	Inherits: ^Prop
 
 camisc06:
-	Defaults:
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 3
+	Inherits: ^Prop
 
 caeuro05:
-	Defaults:
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 3
+	Inherits: ^Prop
 
 capark01:
-	Defaults:
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 3
+	Inherits: ^Prop
 
 capark02:
-	Defaults:
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 3
+	Inherits: ^Prop
 
 capark03:
-	Defaults:
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 3
+	Inherits: ^Prop
 
 ammo01:
+	Inherits: ^Prop
 	idle:
-		ShadowStart: 3
+		UseTilesetCode: false
 
 cabhut:
+	Inherits: ^Prop
 	idle:
-		ShadowStart: 3
+		UseTilesetCode: false
 		Offset: 0, -15
 
 gagate_a:
+	Inherits: ^Prop
 	Defaults:
-		UseTilesetCode: true
 		Offset: 0, -15
 	idle:
 		Length: 10

--- a/mods/ra2/sequences/civilian-structures.yaml
+++ b/mods/ra2/sequences/civilian-structures.yaml
@@ -1,287 +1,116 @@
 cafncb:
-	Defaults:
-		Offset: 0,-15
-		UseTilesetCode: true
-	idle: ctfncb
-		Length: 16
-		ShadowStart: 32
-	damaged-idle: ctfncb
-		Start: 16
-		Length: 16
-		ShadowStart: 48
+	Inherits: ^Wall
+	Defaults: ctfncb
 	icon: wallicon
-		Offset: 0,0
-		UseTilesetCode: false
 
 cafncw:
-	Defaults:
-		Offset: 0,-15
-		UseTilesetCode: true
-	idle: ctfncw
-		Length: 16
-		ShadowStart: 32
-	damaged-idle: ctfncw
-		Start: 16
-		Length: 16
-		ShadowStart: 48
+	Inherits: ^Wall
+	Defaults: ctfncw
 	icon: wallicon
-		Offset: 0,0
-		UseTilesetCode: false
 
 gasand:
-	Defaults:
-		Offset: 0,-15
-		UseTilesetCode: true
-	idle: gtsand
-		Length: 16
-		ShadowStart: 32
-	damaged-idle: gtsand
-		Start: 16
-		Length: 16
-		ShadowStart: 48
+	Inherits: ^Wall
+	Defaults: gtsand
 	icon: wallicon
-		Offset: 0,0
-		UseTilesetCode: false
 
 cafncp:
-	Defaults:
-		Offset: 0,-15
-		UseTilesetCode: true
-	idle: ctfncp
-		Length: 16
-		ShadowStart: 32
-	damaged-idle: ctfncp
-		Start: 16
-		Length: 16
-		ShadowStart: 48
+	Inherits: ^Wall
+	Defaults: ctfncp
 	icon: wallicon
-		Offset: 0,0
-		UseTilesetCode: false
 
 cakrmw:
-	Defaults:
-		Offset: 0,-15
-		UseTilesetCode: true
-	idle: ctkrmw
-		Length: 16
-		ShadowStart: 32
-	damaged-idle: ctkrmw
-		Start: 16
-		Length: 16
-		ShadowStart: 48
+	Inherits: ^Wall
+	Defaults: ctkrmw
 	icon: wallicon
-		Offset: 0,0
-		UseTilesetCode: false
 
 cawash01:
-	Defaults:
+	Inherits: ^CivStructure
+	Defaults: cgwash01
 		Offset: 0,-60
-	idle: cgwash01
-		ShadowStart: 4
-	damaged-idle: cgwash01
-		Start: 1
-		ShadowStart: 5
-	rubble: cgwash01
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
+		UseTilesetCode: false
 
 cawash03:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: -15,-52
-	idle: cuwash03
-		ShadowStart: 4
-	damaged-idle: cuwash03
-		Start: 1
-		ShadowStart: 5
-	rubble: cuwash03
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cawash04:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-60
-	idle: cuwash04
-		ShadowStart: 4
-	damaged-idle: cuwash04
-		Start: 1
-		ShadowStart: 5
-	rubble: cuwash04
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cawash05:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: -30,-45
-	idle: cuwash05
-		ShadowStart: 4
-	damaged-idle: cuwash05
-		Start: 1
-		ShadowStart: 5
-	rubble: cuwash05
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cawash06:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-60
+		UseTilesetCode: false
 	idle: cgwash06_a # Custom artwork, original lacked shadow.
 		ShadowStart: 1
 	damaged-idle: cuwash06
-		Start: 1
-		ShadowStart: 5
 	rubble: cuwash06
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cawash07:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-45
-	idle: cuwash07
-		ShadowStart: 4
-	damaged-idle: cuwash07
-		Start: 1
-		ShadowStart: 5
-	rubble: cuwash07
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cawash08:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 15,-52
-	idle: cuwash08
-		ShadowStart: 4
-	damaged-idle: cuwash08
-		Start: 1
-		ShadowStart: 5
-	rubble: cuwash08
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cawash09:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-45
-	idle: cuwash09
-		ShadowStart: 4
-	damaged-idle: cuwash09
-		Start: 1
-		ShadowStart: 5
-	rubble: cuwash09
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cawash10:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-60
-	idle: cuwash10
-		ShadowStart: 4
-	damaged-idle: cuwash10
-		Start: 1
-		ShadowStart: 5
-	rubble: cuwash10
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cawash11:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-60
-	idle: cuwash11
-		ShadowStart: 4
-	damaged-idle: cuwash11
-		Start: 1
-		ShadowStart: 5
-	rubble: cuwash11
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cawsh12:
-	Defaults:
+	Inherits: ^CivStructure
+	Defaults: cgwsh12
 		Offset: 0,-45
-	idle: cgwsh12
-		ShadowStart: 4
-	damaged-idle: cgwsh12
-		Start: 1
-		ShadowStart: 5
-	rubble: cgwsh12
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
+		UseTilesetCode: false
 
 cawash13:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 15,-52
-	idle: cuwash13
-		ShadowStart: 4
-	damaged-idle: cuwash13
-		Start: 1
-		ShadowStart: 5
-	rubble: cuwash13
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cawash14:
-	Defaults:
+	Inherits: ^CivStructure
+	Defaults: cgwash14
 		Offset: 0,-45
-	idle: cgwash14
-		ShadowStart: 4
-	damaged-idle: cgwash14
-		Start: 1
-		ShadowStart: 5
-	rubble: cgwash14
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
+		UseTilesetCode: false
 
 cawash15:
-	Defaults:
+	Inherits: ^CivStructure
+	Defaults: cgwash15
 		Offset: 15,-52
-	idle: cgwash15
-		ShadowStart: 4
-	damaged-idle: cgwash15
-		Start: 1
-		ShadowStart: 5
-	rubble: cgwash15
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
+		UseTilesetCode: false
 
 cawash16:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: -30,-60
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cawash17:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: -30,-75
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cawash18:
 	Defaults:
@@ -295,47 +124,30 @@ cawash18:
 		Tick: 80
 
 cawash19:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-60
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
 	idle-flag: cawa19_a
 		Length: 16
 	damaged-idle-flag: cawa19_a
 		Start: 16
 		Length: 16
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 canewy01:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-60
-	idle: cunewy01
-		ShadowStart: 4
-	damaged-idle: cunewy01
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 canewy04:
-	Defaults:
+	Inherits: ^CivStructure
+	Defaults: cgnewy04
 		Offset: 0,-45
-	idle: cgnewy04
-	damaged-idle: cgnewy04
+		UseTilesetCode: false
+	idle:
+		ShadowStart: -1
+	damaged-idle:
 		Start: 1
-	rubble: cgnewy04
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
+		ShadowStart: -1
 
 canewy05:
 	Defaults:
@@ -345,733 +157,364 @@ canewy05:
 		ShadowStart: 3
 
 canewy06:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-45
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 canewy07:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-45
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 canewy08:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-45
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 canewy10:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: -15,-37
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 canewy11:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: -15,-37
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 canewy12:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 15,-37
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 canewy13:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-45
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 canewy14:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-45
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 canewy15:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-45
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 canewy16:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 0,-30
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 canewy17:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-30
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 canewy18:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-30
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 canewy20:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 30,-60
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 canewy21:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: -30,-60
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 caarmy01:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: -15,-37
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
+	-rubble:
 
 caarmy02:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-15
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 2
+	-rubble:
 
 caarmy03:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-15
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 2
+	-rubble:
 
 caarmy04:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-15
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 2
+	-rubble:
 
 cawa2a:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-60
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cawa2b:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-60
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cawa2c:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 0,-60
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cawa2d:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 0,-60
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cafarm01:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 0,-30
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
+	-rubble:
 
 cafarm02:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 0,-15
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cafarm06:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 0,-30
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 2
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cafrma:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-30
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 2
-		ShadowStart: 5
+	-rubble:
 
 cafrmb:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-15
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 2
+	-rubble:
 
 cabarn02:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 0,-30
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 2
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 causfgl:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 0,-15
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
+	-rubble:
 	flag: causfgl_a
 		Length: 16
 		ShadowStart: 16
 
 carufgl:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 0,-15
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
+	-rubble:
 	flag: carufgl_a
 		Length: 16
 		ShadowStart: 16
 
 cairfgl:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 0,-15
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
+	-rubble:
 	flag: cairfgl_a
 		Length: 16
 		ShadowStart: 16
 
 capofgl:
-	Defaults:
+	Inherits: ^CivStructure
+	Defaults: capofgl
 		Offset: 0,-15
-	idle: capofgl
-		ShadowStart: 4
-	damaged-idle: capofgl
-		Start: 1
-		ShadowStart: 5
+		UseTilesetCode: false
+	-rubble:
 	flag: capofgl_a
 		Length: 16
 		ShadowStart: 16
 
 caskfgl:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 0,-15
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
+	-rubble:
 	flag: cuskfgl_a
 		Length: 16
 		ShadowStart: 16
 
 calbfgl:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 0,-15
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
+	-rubble:
 	flag: culbfgl_a
 		Length: 16
 		ShadowStart: 16
 
 cafrfgl:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 0,-15
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
+	-rubble:
 	flag: cufrfgl_a
 		Length: 16
 		ShadowStart: 16
 
 cagefgl:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 0,-15
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
+	-rubble:
 	flag: cugefgl_a
 		Length: 16
 		ShadowStart: 16
 
 cacufgl:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 0,-15
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
+	-rubble:
 	flag: cucufgl_a
 		Length: 16
 		ShadowStart: 16
 
 caukfgl:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 0,-15
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
+	-rubble:
 	flag: cuukfgl_a
 		Length: 16
 		ShadowStart: 16
 
 camisc01:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 0,-15
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		ShadowStart: 4
+	-rubble:
 
 camisc02:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 0,-15
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
+	-rubble:
 
 camisc03:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 0,-15
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
+	-rubble:
 
 camisc04:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 0,-15
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
+	-rubble:
 
 camisc05:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 0,-15
 	idle:
 		ShadowStart: 2
 	damaged-idle:
-		Start: 1
 		ShadowStart: 3
+	-rubble:
 
 camisc06:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: -15,-22
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
+	-rubble:
 
 camsc07:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 0,-30
-	idle:
-		ShadowStart: 3
-	damaged-idle:
-		Start: 1
-		ShadowStart: 4
+	-rubble:
 
 camsc08:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 0,-15
-	idle:
-		ShadowStart: 3
-	damaged-idle:
-		Start: 1
-		ShadowStart: 4
+	-rubble:
 
 camsc09:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 0,-15
-	idle:
-		ShadowStart: 3
-	damaged-idle:
-		Start: 1
-		ShadowStart: 4
+	-rubble:
 
 camsc10:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 0,-60
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 camsc11:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 0,-15
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
+	-rubble:
 
 camsc12:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 0,-15
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
+	-rubble:
 
 camsc13:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 15,-22
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
+	-rubble:
 
 camiam01:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: -30,-45
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 camiam02:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: -30,-45
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 camiam03:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 15,-37
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 camiam04:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-15
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 3
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
+	-rubble:
 
 camiam05:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 15,-52
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 camiam06:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-60
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 camiam07:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 0,-60
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 camiam08:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: -30,-30
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 castrt01:
 	Defaults:
@@ -1106,396 +549,146 @@ castrt05:
 		ShadowStart: 3
 
 camex01:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: -15,-37
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 2
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 camex02:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: -30,-75
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 2
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 camex03:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-45
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 2
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 camex04:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-60
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 2
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 camex05:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-30
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 2
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 castl01:
-	Defaults:
-		UseTilesetCode: true
+	Inherits: ^CivStructure
+	Defaults: custl01
 		Offset: 0,-60
-	idle: custl01
-		ShadowStart: 4
-	damaged-idle: custl01
-		Start: 1
-		ShadowStart: 5
-	rubble: custl01
-		UseTilesetCode: false
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
+	-rubble:
 
 castl02:
-	Defaults:
+	Inherits: ^CivStructure
+	Defaults: custl02
 		Offset: 0,-60
-		UseTilesetCode: true
-	idle: custl02
-		ShadowStart: 4
-	damaged-idle: custl02
-		Start: 1
-		ShadowStart: 5
-	rubble: custl02
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 castl03:
-	Defaults:
+	Inherits: ^CivStructure
+	Defaults: custl03
 		Offset: 0,-60
-		UseTilesetCode: true
-	idle: custl03
-		ShadowStart: 4
-	damaged-idle: custl03
-		Start: 1
-		ShadowStart: 5
-	rubble: custl03
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 castl04:
-	Defaults:
+	Inherits: ^CivStructure
+	Defaults: cgstl04
 		Offset: 60,-60
-	idle: cgstl04
-		ShadowStart: 3
-	damaged-idle: cgstl04
-		Start: 1
-		ShadowStart: 4
-	rubble: cgstl04
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
+		UseTilesetCode: false
 
 castl05a:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-60
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 castl05b:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-60
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 castl05c:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-60
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 castl05d:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-60
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 castl05e:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-60
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 castl05f:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-60
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 castl05g:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-60
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 castl05h:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-60
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cacolo01:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: -30,-60
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 caind01:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 0,-60
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 calab:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 15,-52
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cagas01:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 0,-45
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cahse01:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: -15,-37
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 4
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cahse02:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: -15,-37
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 4
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cahse03:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 15,-52
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 4
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cahse04:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: -15,-37
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 4
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cahse05:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 15,-22
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cahse06:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: -15,-22
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cahse07:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 15,-37
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cawt01:
 	Defaults:
@@ -1511,559 +704,220 @@ cawt01:
 		ShadowStart: 3
 
 cabunk01:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-30
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cabunk02:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-30
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 carus01:
-	Defaults:
+	Inherits: ^CivStructure
+	Defaults: cgrus01
 		Offset: 0,-60
-	idle: cgrus01
-		ShadowStart: 4
-	damaged-idle: cgrus01
-		Start: 1
-		ShadowStart: 5
-	rubble: cgrus01
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
+		UseTilesetCode: false
 
 carus02a:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-15
 		UseTilesetCode: false
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 carus02b:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-15
 		UseTilesetCode: false
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 carus02c:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-15
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
+	-rubble:
 
 carus02d:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-15
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
+	-rubble:
 
 carus02e:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-15
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
+	-rubble:
 
 carus02f:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-15
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
+	-rubble:
 
 carus02g:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-15
-		UseTilesetCode: false
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
 	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
+		ShadowStart: -1
 
 carus03:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 45,-52
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 carus04:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-60
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 carus05:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-60
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 carus06:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-60
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 carus07:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-15
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 carus08:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-15
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 carus09:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: -15,-22
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 carus10:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: -15,-22
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 carus11:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: -15,-22
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cachig01:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: -15,-37
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cachig02:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 15,-37
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cachig03:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: -15,-37
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cachig04:
-	Defaults:
+	Inherits: ^CivStructure
+	Defaults: cgchig04
 		Offset: 0,-30
-	idle: cgchig04
-		ShadowStart: 4
-	damaged-idle: cgchig04
-		Start: 1
-		ShadowStart: 5
-	rubble: cgchig04
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
+		UseTilesetCode: false
 
 cachig05:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-60
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cachig06:
-	Defaults:
+	Inherits: ^CivStructure
+	Defaults: cgchig06
 		Offset: 0,-30
-	idle: cgchig06
-		ShadowStart: 4
-	damaged-idle: cgchig06
-		Start: 1
-		ShadowStart: 5
-	rubble: cgchig06
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
+		UseTilesetCode: false
 
 catech01:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-45
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 catexs01:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-30
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 catexs02:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-60
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 catexs03:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-45
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 catexs04:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-45
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 catexs05:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-45
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 catexs06:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-45
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 catexs07:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-45
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 catexs08:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 15,-37
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 canwy05:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-60
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 canwy09:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 15,-37
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 canwy22:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-45
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 canwy23:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: -15,-37
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 canwy24:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-45
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 canwy25:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-45
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 canwy26:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: -30,-60
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 camov01:
 	Defaults:
@@ -2083,14 +937,9 @@ camov01:
 		Tick: 200
 
 camov02:
+	Inherits: ^CivStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 0,-30
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
 	idle-overlay: camov02_a
 		Length: 2
 		Tick: 200
@@ -2098,186 +947,74 @@ camov02:
 		Start: 2
 		Length: 2
 		Tick: 200
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 capars01:
-	Defaults:
+	Inherits: ^CivStructure
+	Defaults: cgpars01
 		Offset: 0,-60
-	idle: cgpars01
-		ShadowStart: 4
-	damaged-idle: cgpars01
-		Start: 1
-		ShadowStart: 5
-	rubble: cgpars01
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
+		UseTilesetCode: false
 
 capars02:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: -30,-75
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 capars04:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-45
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 capars05:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-45
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 capars06:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-45
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 capars07:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-15
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
+	-rubble:
 
 capars08:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: -30,-75
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 capars09:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: -30,-75
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 capars10:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: -15,-52
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 capars11:
-	Defaults:
+	Inherits: ^CivStructure
+	Defaults: cgpars11
 		Offset: 15,-52
-	idle: cgpars11
-		ShadowStart: 4
-	damaged-idle: cgpars11
-		Start: 1
-		ShadowStart: 5
-	rubble: cgpars11
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
+		UseTilesetCode: false
 
 capars12:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 30,-60
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 capars13:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 15,-52
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 capars14:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: -15,-52
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 cats01:
 	Defaults:
@@ -2304,74 +1041,29 @@ cagard01:
 		Tick: 80
 
 caeur1:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-30
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 caeur2:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 0,-30
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 caeur04:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: -15,-52
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 caprs03:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: -30,-75
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 caswst01:
+	Inherits: ^CivStructure
 	Defaults:
 		Offset: 15,-37
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
-	rubble:
-		Start: 3
-		ShadowStart: 7
-		ZOffset: -3c0
 
 galite:
 	idle:

--- a/mods/ra2/sequences/civilians.yaml
+++ b/mods/ra2/sequences/civilians.yaml
@@ -1,812 +1,173 @@
 civ1:
-	Inherits@MC: ^MindControllable
-	stand:
-		Facings: 8
-	run:
-		Start: 8
-		Length: 6
-		Facings: 8
-	prone-stand:
-		Start: 182
-		Facings: 8
-	prone-run:
-		Start: 182
-		Length: 6
-		Facings: 8
-	prone-shoot:
-		Facings: 8
-	shoot:
-		Start: 86
-		Length: 6
-		Facings: 8
-	idle1:
-		Start: 56
-		Length: 15
-	die1:
-		Start: 71
-		Length: 15
-	die2:
-		Length: 8
-	die4: nukedie
-		Length: *
-		Tick: 50
-	die6: electro
-		Length: *
-		Tick: 80
-	cheer:
-		Start: 230
-		Length: 15
-	panic-stand:
-		Start: 134
-		Length: 6
-		Facings: 8
-	panic-run:
-		Start: 134
-		Length: 6
-		Facings: 8
+	Inherits: ^CivInfantry
 
 civ2:
-	Inherits@MC: ^MindControllable
-	stand:
-		Facings: 8
-	run:
-		Start: 8
-		Length: 6
-		Facings: 8
-	prone-stand:
-		Start: 182
-		Facings: 8
-	prone-run:
-		Start: 182
-		Length: 6
-		Facings: 8
-	prone-shoot:
-		Facings: 8
-	shoot:
-		Start: 86
-		Length: 6
-		Facings: 8
-	idle1:
-		Start: 56
-		Length: 15
-	die1:
-		Start: 71
-		Length: 15
-	die2:
-		Length: 8
-	die4: nukedie
-		Length: *
-		Tick: 50
-	die6: electro
-		Length: *
-		Tick: 80
-	cheer:
-		Start: 230
-		Length: 15
-	panic-stand:
-		Start: 134
-		Length: 6
-		Facings: 8
-	panic-run:
-		Start: 134
-		Length: 6
-		Facings: 8
+	Inherits: ^CivInfantry
 
 civ3:
-	Inherits@MC: ^MindControllable
-	stand:
-		Facings: 8
-	run:
-		Start: 8
-		Length: 6
-		Facings: 8
-	prone-stand:
-		Start: 182
-		Facings: 8
-	prone-run:
-		Start: 180
-		Length: 6
-		Facings: 8
-	prone-shoot:
-		Facings: 8
-	shoot:
-		Start: 84
-		Length: 6
-		Facings: 8
-	idle1:
-		Start: 56
-		Length: 15
+	Inherits: ^CivInfantry
 	die1:
-		Start: 71
 		Length: 13
 	die2:
-		Length: 8
-	die4: nukedie
-		Length: *
-		Tick: 50
-	die6: electro
-		Length: *
-		Tick: 80
+		Length: 13
+	prone-stand:
+		Frames: 180, 186, 192, 198, 204, 210, 216, 222
+	prone-run:
+		Start: 180
+	shoot:
+		Start: 84
 	cheer:
 		Start: 228
-		Length: 15
-	panic-stand:
-		Start: 132
-		Length: 6
-		Facings: 8
 	panic-run:
 		Start: 132
-		Length: 6
-		Facings: 8
 
 vladimir:
-	Inherits@MC: ^MindControllable
-	stand:
-		Facings: 8
-	run:
-		Start: 8
-		Length: 6
-		Facings: 8
+	Inherits: ^CivInfantry
 	prone-stand:
-		Start: 86
-		Facings: 8
+		Frames: 86, 92, 98, 104, 110, 116, 122, 128
 	prone-run:
 		Start: 86
-		Length: 6
-		Facings: 8
 	prone-shoot:
 		Start: 212
 		Length: 6
 		Facings: 8
 	shoot:
 		Start: 164
-		Length: 6
-		Facings: 8
-	idle1:
-		Start: 56
-		Length: 15
 	idle2:
 		Start: 71
-		Length: 14
+		Length: 15
 	die1:
 		Start: 134
-		Length: 15
-		Facings: 8
 	die2:
 		Start: 149
-		Length: 15
+	liedown:
+		Start: 260
+		Length: 2
 		Facings: 8
-	die4: nukedie
-		Length: *
-		Tick: 50
-	die6: electro
-		Length: *
-		Tick: 80
-	cheer:
-		Start: 56
-		Length: 15
-	panic-stand:
-		Start: 8
-		Length: 6
+	standup:
+		Start: 276
+		Length: 2
 		Facings: 8
-	panic-run:
-		Start: 8
-		Length: 6
-		Facings: 8
+	-cheer:
+	-panic-stand:
+	-panic-run:
 
 pentgen:
-	Inherits@MC: ^MindControllable
-	stand:
-		Facings: 8
-	run:
-		Start: 8
-		Length: 6
-		Facings: 8
+	Inherits: ^CivInfantry
 	prone-stand:
-		Start: 134
-		Facings: 8
+		Frames: 134, 140, 146, 152, 158, 164, 170, 176
 	prone-run:
 		Start: 134
-		Length: 6
-		Facings: 8
 	prone-shoot:
 		Start: 214
 		Length: 6
 		Facings: 8
-	shoot:
-		Start: 86
-		Length: 6
+	standup:
+		Start: 182
+		Length: 2
 		Facings: 8
-	idle1:
-		Start: 56
-		Length: 15
-	die1:
-		Start: 71
-		Length: 15
-	die2:
-		Length: 8
-	die4: nukedie
-		Length: *
-		Tick: 50
-	die6: electro
-		Length: *
-		Tick: 80
-	cheer:
-		Start: 56
-		Length: 15
-	panic-stand:
-		Start: 8
-		Length: 6
+	liedown:
+		Start: 198
+		Length: 2
 		Facings: 8
-	panic-run:
-		Start: 8
-		Length: 6
-		Facings: 8
+	-cheer:
+	-panic-stand:
+	-panic-run:
 
 pres:
-	Inherits@MC: ^MindControllable
-	stand:
-		Facings: 8
-	run:
-		Start: 8
-		Length: 6
-		Facings: 8
+	Inherits: ^CivInfantry
 	prone-stand:
-		Start: 134
-		Facings: 8
+		Frames: 134, 140, 146, 152, 158, 164, 170, 176
 	prone-run:
 		Start: 134
-		Length: 6
-		Facings: 8
-	prone-shoot:
-		Facings: 8
-	shoot:
-		Facings: 8
-	idle1:
-		Start: 56
-		Length: 15
-	die1:
-		Start: 71
-		Length: 15
-	die2:
-		Length: 8
-	die4: nukedie
-		Length: *
-		Tick: 50
-	die6: electro
-		Length: *
-		Tick: 80
-	cheer:
-		Start: 56
-		Length: 15
-	panic-stand:
-		Start: 86
-		Length: 6
-		Facings: 8
+	-shoot:
+	-cheer:
 	panic-run:
 		Start: 86
-		Length: 6
-		Facings: 8
 
 ssrv:
-	Inherits@MC: ^MindControllable
-	stand:
-		Facings: 8
-	run:
-		Start: 8
-		Length: 6
-		Facings: 8
+	Inherits: ^CivInfantry
 	prone-stand:
-		Start: 182
-		Facings: 8
+		Frames: 134, 140, 146, 152, 158, 164, 170, 176
 	prone-run:
+		Start: 134
+	prone-shoot:
 		Start: 182
 		Length: 6
 		Facings: 8
-	prone-shoot:
-		Start: 86
-		Length: 6
-		Facings: 8
-	shoot:
-		Start: 86
-		Length: 6
-		Facings: 8
-	idle1:
-		Start: 56
-		Length: 15
-	die1:
-		Start: 71
-		Length: 15
-	die2:
-		Length: 8
-	die4: nukedie
-		Length: *
-		Tick: 50
-	die6: electro
-		Length: *
-		Tick: 80
-	cheer:
-		Start: 56
-		Length: 15
-	panic-stand:
-		Start: 134
-		Length: 6
-		Facings: 8
-	panic-run:
-		Start: 134
-		Length: 6
-		Facings: 8
+	-cheer:
+	-panic-stand:
+	-panic-run:
 
 civa:
-	Inherits@MC: ^MindControllable
-	stand:
-		Facings: 8
-	run:
-		Start: 8
-		Length: 6
-		Facings: 8
-	prone-stand:
-		Start: 182
-		Facings: 8
-	prone-run:
-		Start: 182
-		Length: 6
-		Facings: 8
-	prone-shoot:
-		Start: 86
-		Length: 6
-		Facings: 8
-	shoot:
-		Start: 86
-		Length: 6
-		Facings: 8
-	idle1:
-		Start: 56
-		Length: 15
-	die1:
-		Start: 71
-		Length: 15
-	die2:
-		Length: 8
-	die4: nukedie
-		Length: *
-		Tick: 50
-	die6: electro
-		Length: *
-		Tick: 80
-	cheer:
-		Start: 56
-		Length: 15
-	panic-stand:
-		Start: 134
-		Length: 6
-		Facings: 8
-	panic-run:
-		Start: 134
-		Length: 6
-		Facings: 8
+	Inherits: ^CivInfantry
 
 civb:
-	Inherits@MC: ^MindControllable
-	stand:
-		Facings: 8
-	run:
-		Start: 8
-		Length: 6
-		Facings: 8
-	prone-stand:
-		Start: 182
-		Facings: 8
-	prone-run:
-		Start: 182
-		Length: 6
-		Facings: 8
-	prone-shoot:
-		Start: 86
-		Length: 6
-		Facings: 8
-	shoot:
-		Start: 86
-		Length: 6
-		Facings: 8
-	idle1:
-		Start: 56
-		Length: 15
-	die1:
-		Start: 71
-		Length: 15
-	die2:
-		Length: 8
-	die4: nukedie
-		Length: *
-		Tick: 50
-	die6: electro
-		Length: *
-		Tick: 80
-	cheer:
-		Start: 56
-		Length: 15
-	panic-stand:
-		Start: 134
-		Length: 6
-		Facings: 8
-	panic-run:
-		Start: 134
-		Length: 6
-		Facings: 8
+	Inherits: ^CivInfantry
 
 civc:
-	Inherits@MC: ^MindControllable
-	stand:
-		Facings: 8
-	run:
-		Start: 8
-		Length: 6
-		Facings: 8
-	prone-stand:
-		Start: 182
-		Facings: 8
-	prone-run:
-		Start: 182
-		Length: 6
-		Facings: 8
-	prone-shoot:
-		Start: 86
-		Length: 6
-		Facings: 8
-	shoot:
-		Start: 86
-		Length: 6
-		Facings: 8
-	idle1:
-		Start: 56
-		Length: 15
-	die1:
-		Start: 71
-		Length: 15
-	die2:
-		Length: 8
-	die4: nukedie
-		Length: *
-		Tick: 50
-	die6: electro
-		Length: *
-		Tick: 80
-	cheer:
-		Start: 56
-		Length: 15
-	panic-stand:
-		Start: 134
-		Length: 6
-		Facings: 8
-	panic-run:
-		Start: 134
-		Length: 6
-		Facings: 8
+	Inherits: ^CivInfantry
 
 civbbp:
-	Inherits@MC: ^MindControllable
-	stand:
-		Facings: 8
-	run:
-		Start: 8
-		Length: 6
-		Facings: 8
-	prone-stand:
-		Start: 134
-		Facings: 8
-	prone-run:
-		Start: 134
-		Length: 6
-		Facings: 8
-	prone-shoot:
-		Facings: 8
-	shoot:
-		Facings: 8
-	idle1:
-		Start: 56
-		Length: 15
-	die1:
-		Start: 71
-		Length: 15
-	die2:
-		Length: 8
-	die4: nukedie
-		Length: *
-		Tick: 50
-	die6: electro
-		Length: *
-		Tick: 80
-	cheer:
-		Start: 56
-		Length: 15
-	panic-stand:
-		Start: 86
-		Length: 6
-		Facings: 8
-	panic-run:
-		Start: 86
-		Length: 6
-		Facings: 8
+	Inherits: ^CivInfantry
 
 civbfm:
-	Inherits@MC: ^MindControllable
-	stand:
-		Facings: 8
-	run:
-		Start: 8
-		Length: 6
-		Facings: 8
+	Inherits: ^CivInfantry
+	-shoot:
 	prone-stand:
-		Start: 134
-		Facings: 8
+		Frames: 134, 140, 146, 152, 158, 164, 170, 176
 	prone-run:
 		Start: 134
-		Length: 6
-		Facings: 8
-	prone-shoot:
-		Facings: 8
-	shoot:
-		Facings: 8
-	idle1:
-		Start: 56
-		Length: 15
-	die1:
-		Start: 71
-		Length: 15
-	die2:
-		Length: 8
-	die4: nukedie
-		Length: *
-		Tick: 50
-	die6: electro
-		Length: *
-		Tick: 80
-	cheer:
-		Start: 56
-		Length: 15
-	panic-stand:
-		Start: 86
-		Length: 6
-		Facings: 8
 	panic-run:
 		Start: 86
-		Length: 6
-		Facings: 8
+	cheer:
+		Start: 182
 
 civbf:
-	Inherits@MC: ^MindControllable
-	stand:
-		Facings: 8
-	run:
-		Start: 8
-		Length: 6
-		Facings: 8
+	Inherits: ^CivInfantry
+	-shoot:
 	prone-stand:
-		Start: 134
-		Facings: 8
+		Frames: 134, 140, 146, 152, 158, 164, 170, 176
 	prone-run:
 		Start: 134
-		Length: 6
-		Facings: 8
-	prone-shoot:
-		Facings: 8
-	shoot:
-		Facings: 8
-	idle1:
-		Start: 56
-		Length: 15
-	die1:
-		Start: 71
-		Length: 15
-	die2:
-		Length: 8
-	die4: nukedie
-		Length: *
-		Tick: 50
-	die6: electro
-		Length: *
-		Tick: 80
-	cheer:
-		Start: 56
-		Length: 15
-	panic-stand:
-		Start: 86
-		Length: 6
-		Facings: 8
 	panic-run:
 		Start: 86
-		Length: 6
-		Facings: 8
+	cheer:
+		Start: 182
 
 civbtm:
-	Inherits@MC: ^MindControllable
-	stand:
-		Facings: 8
-	run:
-		Start: 8
-		Length: 6
-		Facings: 8
+	Inherits: ^CivInfantry
+	-shoot:
 	prone-stand:
-		Start: 134
-		Facings: 8
+		Frames: 134, 140, 146, 152, 158, 164, 170, 176
 	prone-run:
 		Start: 134
-		Length: 6
-		Facings: 8
-	prone-shoot:
-		Facings: 8
-	shoot:
-		Facings: 8
-	idle1:
-		Start: 56
-		Length: 15
-	die1:
-		Start: 71
-		Length: 15
-	die2:
-		Length: 8
-	die4: nukedie
-		Length: *
-		Tick: 50
-	die6: electro
-		Length: *
-		Tick: 80
-	cheer:
-		Start: 56
-		Length: 15
-	panic-stand:
-		Start: 86
-		Length: 6
-		Facings: 8
 	panic-run:
 		Start: 86
-		Length: 6
-		Facings: 8
+	cheer:
+		Start: 182
 
 civsfm:
-	Inherits@MC: ^MindControllable
-	stand:
-		Facings: 8
-	run:
-		Start: 8
-		Length: 6
-		Facings: 8
-	prone-stand:
-		Start: 182
-		Facings: 8
-	prone-run:
-		Start: 182
-		Length: 6
-		Facings: 8
-	prone-shoot:
-		Start: 86
-		Length: 6
-		Facings: 8
-	shoot:
-		Start: 86
-		Length: 6
-		Facings: 8
-	idle1:
-		Start: 56
-		Length: 15
-	die1:
-		Start: 71
-		Length: 15
-	die2:
-		Length: 8
-	die4: nukedie
-		Length: *
-		Tick: 50
-	die6: electro
-		Length: *
-		Tick: 80
+	Inherits: ^CivInfantry
 	cheer:
-		Start: 56
-		Length: 15
-	panic-stand:
-		Start: 134
-		Length: 6
-		Facings: 8
-	panic-run:
-		Start: 134
-		Length: 6
-		Facings: 8
+		Start: 231
 
 civsf:
-	Inherits@MC: ^MindControllable
-	stand:
-		Facings: 8
-	run:
-		Start: 8
-		Length: 6
-		Facings: 8
-	prone-stand:
-		Start: 182
-		Facings: 8
-	prone-run:
-		Start: 182
-		Length: 6
-		Facings: 8
-	prone-shoot:
-		Start: 86
-		Length: 6
-		Facings: 8
-	shoot:
-		Start: 86
-		Length: 6
-		Facings: 8
-	idle1:
-		Start: 56
-		Length: 15
-	die1:
-		Start: 71
-		Length: 15
-	die2:
-		Length: 8
-	die4: nukedie
-		Length: *
-		Tick: 50
-	die6: electro
-		Length: *
-		Tick: 80
-	cheer:
-		Start: 56
-		Length: 15
-	panic-stand:
-		Start: 134
-		Length: 6
-		Facings: 8
-	panic-run:
-		Start: 134
-		Length: 6
-		Facings: 8
+	Inherits: ^CivInfantry
 
 civstm:
-	Inherits@MC: ^MindControllable
-	stand:
-		Facings: 8
-	run:
-		Start: 8
-		Length: 6
-		Facings: 8
-	prone-stand:
-		Start: 182
-		Facings: 8
-	prone-run:
-		Start: 182
-		Length: 6
-		Facings: 8
-	prone-shoot:
-		Start: 86
-		Length: 6
-		Facings: 8
-	shoot:
-		Start: 86
-		Length: 6
-		Facings: 8
-	idle1:
-		Start: 56
-		Length: 15
+	Inherits: ^CivInfantry
 	die1:
-		Start: 71
-		Length: 15
+		Length: 13
 	die2:
-		Length: 8
-	die4: nukedie
-		Length: *
-		Tick: 50
-	die6: electro
-		Length: *
-		Tick: 80
+		Length: 13
+	prone-stand:
+		Frames: 180, 186, 192, 198, 204, 210, 216, 222
+	prone-run:
+		Start: 180
+	shoot:
+		Start: 84
 	cheer:
-		Start: 56
-		Length: 15
-	panic-stand:
-		Start: 134
-		Length: 6
-		Facings: 8
+		Start: 228
 	panic-run:
-		Start: 134
-		Length: 6
-		Facings: 8
+		Start: 132

--- a/mods/ra2/sequences/defaults.yaml
+++ b/mods/ra2/sequences/defaults.yaml
@@ -1,4 +1,4 @@
-^BasicInfantry:
+^Animal:
 	stand:
 		Facings: 8
 	run:
@@ -9,10 +9,23 @@
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 120
 	idle2:
 		Start: 71
 		Length: 15
+	die1:
+		Start: 86
+		Length: 15
+	die2:
+		Start: 101
+		Length: 15
+	paradrop:
+	icon: xxicon
+
+^BasicInfantry:
+	Inherits: ^Animal
+	idle1:
+		Tick: 120
+	idle2:
 		Tick: 120
 	cheer:
 		Start: 245
@@ -20,10 +33,8 @@
 		Tick: 120
 	die1:
 		Start: 134
-		Length: 15
 	die2:
 		Start: 149
-		Length: 15
 	die4: nukedie
 		Length: *
 		Tick: 50
@@ -33,7 +44,6 @@
 	die6: electro
 		Length: *
 		Tick: 80
-	paradrop:
 
 ^ProneInfantry:
 	liedown:
@@ -56,6 +66,34 @@
 ^Infantry:
 	Inherits@1: ^BasicInfantry
 	Inherits@2: ^ProneInfantry
+
+^CivInfantry:
+	Inherits: ^Infantry
+	Inherits@MC: ^MindControllable
+	-idle2:
+	die1:
+		Start: 71
+	die2:
+		Start: 71
+	-standup:
+	-liedown:
+	prone-stand:
+		Frames: 182, 188, 194, 200, 206, 212, 218, 224
+	prone-run:
+		Start: 182
+	shoot:
+		Start: 86
+		Length: 6
+		Facings: 8
+	cheer:
+		Start: 230
+		Length: 8
+	panic-stand:
+		Facings: 8
+	panic-run:
+		Start: 134
+		Length: 6
+		Facings: 8
 
 ^ArmedInfantry:
 	Inherits: ^Infantry
@@ -80,3 +118,106 @@
 	mindcontrol: yuricntl
 		Length: *
 		Offset: 0, -24, 24
+
+^bridge:
+	Defaults:
+		ZOffset: -1c511
+		UseTilesetExtension: true
+		Start: 1
+		ZRamp: 1
+		Offset: 0, 0, 0.5
+
+^Structure:
+	Defaults:
+		UseTilesetCode: true
+		TilesetOverrides:
+			TEMPERATE: GENERIC
+			URBAN: GENERIC
+	idle:
+		ShadowStart: 3
+	make:
+		Length: 25
+		ShadowStart: 25
+		TilesetOverrides:
+			TEMPERATE: TEMPERATE
+			URBAN: URBAN
+	damaged-idle:
+		Start: 1
+		ShadowStart: 4
+	icon:
+		Offset: 0,0
+		UseTilesetCode: false
+
+^TechStructure:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+	flag:
+		Length: 16
+
+^CivStructure:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 4
+	damaged-idle:
+		Start: 1
+		ShadowStart: 5
+	rubble:
+		Start: 3
+		ShadowStart: 7
+		ZOffset: -3c0
+
+^Wall:
+	Defaults:
+		Offset: 0,-15
+		UseTilesetCode: true
+	idle:
+		Length: 16
+		ShadowStart: 32
+	damaged-idle:
+		Start: 16
+		Length: 16
+		ShadowStart: 48
+	icon:
+		Offset: 0,0
+		UseTilesetCode: false
+
+^Pole:
+	Defaults:
+		UseTilesetExtension: true
+	idle:
+		ShadowStart: 1
+
+^Prop:
+	Defaults:
+		UseTilesetCode: true
+	idle:
+		ShadowStart: 3
+
+^Rock:
+	idle:
+		ShadowStart: 1
+		Offset: 0, -15
+		UseTilesetExtension: true
+
+^Drill:
+	Defaults:
+		UseTilesetExtension: true
+		Offset: -1, -16
+	idle:
+		ShadowStart: 11
+	active:
+		Start: 1
+		Length: 10
+		ShadowStart: 12
+		Tick: 160
+
+^Tree:
+	idle:
+		ShadowStart: 1
+		UseTilesetExtension: true

--- a/mods/ra2/sequences/misc.yaml
+++ b/mods/ra2/sequences/misc.yaml
@@ -403,64 +403,34 @@ bombcurs:
 		Tick: 300
 
 trock01:
-	idle:
-		ShadowStart: 1
-		Offset: 0, -15
-		UseTilesetExtension: true
+	Inherits: ^Rock
 
 trock02:
-	idle:
-		ShadowStart: 1
-		Offset: 0, -15
-		UseTilesetExtension: true
+	Inherits: ^Rock
 
 trock03:
-	idle:
-		ShadowStart: 1
-		Offset: 0, -15
-		UseTilesetExtension: true
+	Inherits: ^Rock
 
 trock04:
-	idle:
-		ShadowStart: 1
-		Offset: 0, -15
-		UseTilesetExtension: true
+	Inherits: ^Rock
 
 trock05:
-	idle:
-		ShadowStart: 1
-		Offset: 0, -15
-		UseTilesetExtension: true
+	Inherits: ^Rock
 
 srock01:
-	idle:
-		ShadowStart: 1
-		Offset: 0, -15
-		UseTilesetExtension: true
+	Inherits: ^Rock
 
 srock02:
-	idle:
-		ShadowStart: 1
-		Offset: 0, -15
-		UseTilesetExtension: true
+	Inherits: ^Rock
 
 srock03:
-	idle:
-		ShadowStart: 1
-		Offset: 0, -15
-		UseTilesetExtension: true
+	Inherits: ^Rock
 
 srock04:
-	idle:
-		ShadowStart: 1
-		Offset: 0, -15
-		UseTilesetExtension: true
+	Inherits: ^Rock
 
 srock05:
-	idle:
-		ShadowStart: 1
-		Offset: 0, -15
-		UseTilesetExtension: true
+	Inherits: ^Rock
 
 camera:
 	idle:

--- a/mods/ra2/sequences/soviet-structures.yaml
+++ b/mods/ra2/sequences/soviet-structures.yaml
@@ -1,25 +1,18 @@
 nacnst:
+	Inherits: ^Structure
 	Defaults:
 		Offset: 4, -58
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: ngcnst_c
 		Length: 1
 		ShadowStart: 4
 		Tick: 150
 	damaged-idle: ngcnst_c
-		Start: 1
 		Length: 1
 		ShadowStart: 5
 		Tick: 150
 	make: ntcnstmk
 		Length: 31
 		ShadowStart: 31
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 	idle-top: ngcnst_a
 		Length: 11
 		Tick: 200
@@ -31,8 +24,6 @@ nacnst:
 		ShadowStart: 3
 		ZOffset: -1024
 	damaged-idle-normal: ngcnst
-		Start: 1
-		ShadowStart: 4
 		ZOffset: -1024
 	build: ngcnst_b
 		Length: 21
@@ -46,21 +37,13 @@ nacnst:
 		ShadowStart: 25
 		Tick: 100
 	icon: scnsicon
-		Offset: 0,0
-		UseTilesetCode: false
 
 napowr:
+	Inherits: ^Structure
 	Defaults:
 		Offset: -15, -37
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: ngpowr
-		ShadowStart: 3
 	damaged-idle: ngpowr
-		Start: 1
-		ShadowStart: 4
 	critical-idle: ngpowr
 		Start: 2
 		ShadowStart: 5
@@ -78,56 +61,29 @@ napowr:
 	make: ntpowrmk
 		Length: 26
 		ShadowStart: 26
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 	icon: npwricon
-		Offset: 0,0
-		UseTilesetCode: false
 
 nahand:
+	Inherits: ^Structure
 	Defaults:
 		Offset: 1, -31
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: nghand
-		ShadowStart: 3
 	damaged-idle: nghand
-		Start: 1
-		ShadowStart: 4
 	critical-idle: nghand
 		Start: 2
 		ShadowStart: 5
 	make: nthandmk
-		Length: 25
-		ShadowStart: 25
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 	icon: handicon
-		Offset: 0,0
-		UseTilesetCode: false
 
 narefn:
+	Inherits: ^Structure
 	Defaults:
 		Offset: -13, -53
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: ngrefn
-		ShadowStart: 3
 	damaged-idle: ngrefn
-		Start: 1
-		ShadowStart: 4
 	make: ntrefnmk
 		Length: 26
 		ShadowStart: 26
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 	idle-drill: ngrefnl1
 		Length: 3
 		Tick: 1500
@@ -142,21 +98,13 @@ narefn:
 		Length: 20
 		ShadowStart: 20
 	icon: nreficon
-		Offset: 0,0
-		UseTilesetCode: false
 
 naradr:
+	Inherits: ^Structure
 	Defaults:
 		Offset: 2, -31
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: ngradr
-		ShadowStart: 3
 	damaged-idle: ngradr
-		Start: 1
-		ShadowStart: 4
 	critical-idle: ngradr
 		Start: 2
 		ShadowStart: 5
@@ -172,26 +120,15 @@ naradr:
 	make: ntradrmk
 		Length: 30
 		ShadowStart: 30
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 	icon: nradicon
-		Offset: 0,0
-		UseTilesetCode: false
 
 naweap:
+	Inherits: ^Structure
 	Defaults:
 		Offset: -30, -60
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: ngweap
-		ShadowStart: 3
 		ZOffset: -1536
 	damaged-idle: ngweap
-		Start: 1
-		ShadowStart: 4
 		ZOffset: -1536
 	build-door: ngweap_1
 		ShadowStart: 2
@@ -234,22 +171,12 @@ naweap:
 		ShadowStart: 13
 		Tick: 150
 	make: ntweapmk
-		Length: 25
-		ShadowStart: 25
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 	icon: nwepicon
-		Offset: 0,0
-		UseTilesetCode: false
 
 nayard:
+	Inherits: ^Structure
 	Defaults:
 		Offset: 0, -45
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: ngyard
 		ShadowStart: 4
 	damaged-idle: ngyard
@@ -281,11 +208,6 @@ nayard:
 		Length: 15
 		ZOffset: 256
 	make: ntyardmk
-		Length: 25
-		ShadowStart: 25
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 	repair: ngyard_s
 		Length: 18
 		ShadowStart: 36
@@ -294,16 +216,11 @@ nayard:
 		Length: 18
 		ShadowStart: 54
 	icon: yardicon
-		Offset: 0,0
-		UseTilesetCode: false
 
 nadept:
+	Inherits: ^Structure
 	Defaults:
 		Offset: -15, -53
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: ngdept_b
 		Length: 10
 		ShadowStart: 20
@@ -324,11 +241,6 @@ nadept:
 		Start: 1
 		ShadowStart: 2
 	make: ntdeptmk
-		Length: 25
-		ShadowStart: 25
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 	repair: ngdept_c
 		Length: 50
 		ShadowStart: 100
@@ -339,21 +251,13 @@ nadept:
 		ShadowStart: 150
 		Tick: 120
 	icon: rfixicon
-		Offset: 0,0
-		UseTilesetCode: false
 
 nanrct:
+	Inherits: ^Structure
 	Defaults:
 		Offset: -12, -56
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: ngnrct
-		ShadowStart: 3
 	damaged-idle: ngnrct
-		Start: 1
-		ShadowStart: 4
 	critical-idle: ngnrct
 		Start: 2
 		ShadowStart: 5
@@ -369,47 +273,24 @@ nanrct:
 		Length: 11
 		Tick: 150
 	make: ntnrctmk
-		Length: 25
-		ShadowStart: 25
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 	icon: nrcticon
-		Offset: 0,0
-		UseTilesetCode: false
 
 natech:
+	Inherits: ^Structure
 	Defaults:
 		Offset: 0, -45
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: ngtech
-		ShadowStart: 3
 	damaged-idle: ngtech
-		Start: 1
-		ShadowStart: 4
 	critical-idle: ngtech
 		Start: 2
 		ShadowStart: 5
 	make: nttechmk
-		Length: 25
-		ShadowStart: 25
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 	icon: ntchicon
-		Offset: 0,0
-		UseTilesetCode: false
 
 naclon:
+	Inherits: ^Structure
 	Defaults:
 		Offset: 0, -30
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: ngclon_a
 		Length: 11
 		ShadowStart: 22
@@ -423,27 +304,14 @@ naclon:
 		Length: 11
 		ShadowStart: 33
 	make: ntclonmk
-		Length: 25
-		ShadowStart: 25
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 	icon: clonicon
-		Offset: 0,0
-		UseTilesetCode: false
 
 napsis:
+	Inherits: ^Structure
 	Defaults:
 		Offset: 1, -30
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: ngpsis
-		ShadowStart: 3
 	damaged-idle: ngpsis
-		Start: 1
-		ShadowStart: 4
 	critical-idle: ngpsis
 		Start: 2
 		ShadowStart: 5
@@ -459,20 +327,17 @@ napsis:
 	make: ntpsismk
 		Length: 24
 		ShadowStart: 24
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 	icon: psisicon
-		Offset: 0,0
-		UseTilesetCode: false
 
 namisl:
+	Inherits: ^Structure
 	Defaults:
 		Offset: 0, -42
+		UseTilesetCode: false
+		-TilesetOverrides:
 	idle: ngmisl_e
 		ShadowStart: 2
 	damaged-idle: ngmisl_e
-		Start: 1
 		ShadowStart: 3
 	critical-idle: ngmisl_e
 		Start: 1
@@ -491,19 +356,12 @@ namisl:
 		UseTilesetCode: true
 		Length: 26
 		ShadowStart: 26
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 	icon: msslicon
-		Offset: 0,0
 
 nairon:
+	Inherits: ^Structure
 	Defaults:
 		Offset: 0, -45
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: ngiron_a
 		Length: 11
 		ShadowStart: 22
@@ -519,19 +377,13 @@ nairon:
 		Length: 12
 		ShadowStart: 36
 	make: ntironmk
-		Length: 25
-		ShadowStart: 25
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 	icon: ironicon
-		Offset: 0,0
-		UseTilesetCode: false
 
 nawall:
+	Inherits: ^Structure
 	Defaults:
 		Offset: 0, -12
-		UseTilesetCode: true
+		-TilesetOverrides:
 	idle: ntwall
 		Length: 16
 		ShadowStart: 48
@@ -544,49 +396,30 @@ nawall:
 		Length: 16
 		ShadowStart: 80
 	icon: nwalicon
-		Offset: 0,0
-		UseTilesetCode: false
 
 nalasr:
+	Inherits: ^Structure
 	Defaults:
 		Offset: 0, -20
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: nalasr
-		ShadowStart: 3
 	damaged-idle: nalasr
-		Start: 1
-		ShadowStart: 4
 	critical-idle: nalasr
 		Start: 2
 		ShadowStart: 5
 	make: nalasrmk
 		Length: 12
 		ShadowStart: 12
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 		ZOffset: 0
 	icon: plticon
-		Offset: 0,0
-		UseTilesetCode: false
 
 tesla:
+	Inherits: ^Structure
 	Defaults:
 		Offset: 0, -15
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: ngtsla
 		Length: 1
-		ShadowStart: 3
 	damaged-idle: ngtsla
-		Start: 1
 		Length: 1
-		ShadowStart: 4
 	idle-powered: ngtsla_a
 		Length: 10
 		ShadowStart: 20
@@ -610,38 +443,20 @@ tesla:
 		ShadowStart: 20
 		Tick: 100
 	make: nttslamk
-		Length: 25
-		ShadowStart: 25
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 	icon: tslaicon
-		Offset: 0,0
-		UseTilesetCode: false
 
 naflak:
+	Inherits: ^Structure
 	Defaults:
 		Offset: 0, -15
 		ZOffset: -512
-		UseTilesetCode: true
-		TilesetOverrides:
-			TEMPERATE: GENERIC
-			URBAN: GENERIC
 	idle: ngflak
-		ShadowStart: 3
 	damaged-idle: ngflak
-		Start: 1
-		ShadowStart: 4
 	critical-idle: ngflak
 		Start: 2
 		ShadowStart: 5
 	make: ntflakmk
 		Length: 9
 		ShadowStart: 9
-		TilesetOverrides:
-			TEMPERATE: TEMPERATE
-			URBAN: URBAN
 		ZOffset: 0
 	icon: flakicon
-		Offset: 0,0
-		UseTilesetCode: false

--- a/mods/ra2/sequences/tech-structures.yaml
+++ b/mods/ra2/sequences/tech-structures.yaml
@@ -1,35 +1,21 @@
 caoild:
+	Inherits: ^TechStructure
 	Defaults:
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-		Offset: 0, -30
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
 		Offset: 0, -30
 	idle-pump: caoild_a
 		Length: 32
 		ShadowStart: 64
-		Offset: 0, -30
 	damaged-idle-pump: caoild_a
 		Start: 32
 		Length: 32
 		ShadowStart: 96
-		Offset: 0, -30
 	flag: caoild_f
-		Length: 16
 		Offset: 0, -9
 
 caairp:
+	Inherits: ^TechStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: 7, -40
-	idle:
-		ShadowStart: 4
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
 	idle-overlay: caairp_a
 		Length: 10
 		Tick: 400
@@ -38,35 +24,26 @@ caairp:
 		Length: 10
 		Tick: 400
 	flag: caairp_f
-		Length: 16
 		ZOffset: 128
 
 cahosp:
+	Inherits: ^TechStructure
 	Defaults:
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 4
-		Offset: -30, -75
-	damaged-idle:
-		Start: 1
-		ShadowStart: 5
 		Offset: -30, -75
 	idle-overlay: cahosp_a
 		Length: 2
-		Offset: -30, -75
 		Tick: 400
 	damaged-idle-overlay: cahosp_a
 		Start: 2
 		Length: 2
-		Offset: -30, -75
 		Tick: 400
 	flag: cahosp_f
-		Length: 16
 		ZOffset: 128
+		Offset: 0,0
 
 caoutp:
+	Inherits: ^TechStructure
 	Defaults:
-		UseTilesetCode: true
 		Offset: -15, -50
 	idle-tower:
 		ShadowStart: 4
@@ -76,7 +53,6 @@ caoutp:
 	idle: caoutp_d
 		ShadowStart: 2
 	damaged-idle: caoutp_d
-		Start: 1
 		ShadowStart: 3
 	active-crane: caoutp_a
 		Length: 10
@@ -91,4 +67,3 @@ caoutp:
 	damaged-bib: caoutpbb
 		Start: 1
 	flag: caoutp_f
-		Length: 16

--- a/mods/ra2/sequences/trees.yaml
+++ b/mods/ra2/sequences/trees.yaml
@@ -1,175 +1,92 @@
 tibtre01:
-	Defaults:
-		UseTilesetExtension: true
-		Offset: -1, -16
-	idle:
-		ShadowStart: 11
-	active:
-		Start: 1
-		Length: 10
-		ShadowStart: 12
-		Tick: 160
+	Inherits: ^Drill
 
 tibtre02:
-	Defaults:
-		UseTilesetExtension: true
-		Offset: -1, -16
-	idle:
-		ShadowStart: 11
-	active:
-		Start: 1
-		Length: 10
-		ShadowStart: 12
-		Tick: 160
+	Inherits: ^Drill
 
 tibtre03:
-	Defaults:
-		UseTilesetExtension: true
-		Offset: -1, -16
-	idle:
-		ShadowStart: 11
-	active:
-		Start: 1
-		Length: 10
-		ShadowStart: 12
-		Tick: 160
+	Inherits: ^Drill
 
 tree01:
-	idle:
-		ShadowStart: 1
-		UseTilesetExtension: true
+	Inherits: ^Tree
 
 tree02:
-	idle:
-		ShadowStart: 1
-		UseTilesetExtension: true
+	Inherits: ^Tree
 
 tree03:
-	idle:
-		ShadowStart: 1
-		UseTilesetExtension: true
+	Inherits: ^Tree
 
 tree04:
-	idle:
-		ShadowStart: 1
-		UseTilesetExtension: true
+	Inherits: ^Tree
 
 tree05:
-	idle:
-		ShadowStart: 1
-		UseTilesetExtension: true
+	Inherits: ^Tree
 
 tree06:
-	idle:
-		ShadowStart: 1
-		UseTilesetExtension: true
+	Inherits: ^Tree
 
 tree07:
-	idle:
-		ShadowStart: 1
-		UseTilesetExtension: true
+	Inherits: ^Tree
 
 tree08:
-	idle:
-		ShadowStart: 1
-		UseTilesetExtension: true
+	Inherits: ^Tree
 
 tree09:
-	idle:
-		ShadowStart: 1
-		UseTilesetExtension: true
+	Inherits: ^Tree
 
 tree10:
-	idle:
-		ShadowStart: 1
-		UseTilesetExtension: true
+	Inherits: ^Tree
 
 tree11:
-	idle:
-		ShadowStart: 1
-		UseTilesetExtension: true
+	Inherits: ^Tree
 
 tree12:
-	idle:
-		ShadowStart: 1
-		UseTilesetExtension: true
+	Inherits: ^Tree
 
 tree13:
-	idle:
-		ShadowStart: 1
-		UseTilesetExtension: true
+	Inherits: ^Tree
 
 tree14:
-	idle:
-		ShadowStart: 1
-		UseTilesetExtension: true
+	Inherits: ^Tree
 
 tree15:
-	idle:
-		ShadowStart: 1
-		UseTilesetExtension: true
+	Inherits: ^Tree
 
 tree16:
-	idle:
-		ShadowStart: 1
-		UseTilesetExtension: true
+	Inherits: ^Tree
 
 tree17:
-	idle:
-		ShadowStart: 1
-		UseTilesetExtension: true
+	Inherits: ^Tree
 
 tree18:
-	idle:
-		ShadowStart: 1
-		UseTilesetExtension: true
+	Inherits: ^Tree
 
 tree19:
-	idle:
-		ShadowStart: 1
-		UseTilesetExtension: true
+	Inherits: ^Tree
 
 tree20:
-	idle:
-		ShadowStart: 1
-		UseTilesetExtension: true
+	Inherits: ^Tree
 
 tree21:
-	idle:
-		ShadowStart: 1
-		UseTilesetExtension: true
+	Inherits: ^Tree
 
 tree22:
-	idle:
-		ShadowStart: 1
-		UseTilesetExtension: true
+	Inherits: ^Tree
 
 tree23:
-	idle:
-		ShadowStart: 1
-		UseTilesetExtension: true
+	Inherits: ^Tree
 
 tree24:
-	idle:
-		ShadowStart: 1
-		UseTilesetExtension: true
+	Inherits: ^Tree
 
 tree25:
-	idle:
-		ShadowStart: 1
-		UseTilesetExtension: true
+	Inherits: ^Tree
 
 tree26:
-	idle:
-		ShadowStart: 1
-		UseTilesetExtension: true
+	Inherits: ^Tree
 
 tree27:
-	idle:
-		ShadowStart: 1
-		UseTilesetExtension: true
+	Inherits: ^Tree
 
 tree28:
-	idle:
-		ShadowStart: 1
-		UseTilesetExtension: true
+	Inherits: ^Tree

--- a/mods/ra2/sequences/voxels.yaml
+++ b/mods/ra2/sequences/voxels.yaml
@@ -22,7 +22,7 @@ car:
 carrier:
 	idle:
 
-cdest:	#coast guard boat/SP unit
+cdest:
 	idle:
 #Needs without weapon image cdestwo
 
@@ -62,7 +62,7 @@ falc:
 naflak:
 	turret: flaktur
 
-flata: #Unused
+flata:
 	idle:
 
 fv:
@@ -86,54 +86,54 @@ harv:
 	turret: harvtur
 	unload: horv
 
-hind: #Unused
+hind:
 	idle:
 
 hornet:
 	idle:
 
-htk: #Flak Track
+htk:
 	idle:
 	turret: htktur
 	barrel: htkbarl
 
-htnk: #Rhino Tank
+htnk:
 	idle:
 	turret: htnktur
 	barrel: htnkbarl
 
-howi: #Howitzer Unused
+howi:
 	idle: hwtz
 
-hyd: #Sea Scorpion
+hyd:
 	idle:
 
 nalasr:
 	turret: laser
 
-lcrf: #Allied transport
+lcrf:
 	idle:
 
 limo:
 	idle:
 
-ltnk: #Light tank,Beta unit. Appears only in one mission as a prop
+ltnk:
 	idle:
 	turret: ltnktur
 	barrel: ltnkbarl
 
-apoc: #Aplocalypse Tank
+apoc:
 	idle: mtnk
 	turret: mtnktur
 	barrel: mtnkbarl
 
-caoutp: #Tech outpost sam
+caoutp:
 	turret: outp
 
-pdplane: #Paradrop plane
+pdplane:
 	idle:
 
-pick: #Cargo Truck
+pick:
 	idle:
 
 #piece: # TODO: unused debris
@@ -142,16 +142,16 @@ pick: #Cargo Truck
 propa:
 	idle:
 
-ptruck: #Pickup Truck
+ptruck:
 	idle:
 
-mgtk: #Mirage Tank, the tur and barrel files are beta, final has fixed turret
+mgtk:
 	idle: rtnk
 
 nasam:
 	turret: sam
 
-shad: #Nighthawk
+shad:
 	idle:
 
 smcv:
@@ -164,7 +164,7 @@ sref: #Has 3 charge states for the turret not possible yet
 stang:
 	idle:
 
-sub: #Typhoon Attack Sub
+sub:
 	idle:
 
 subt: #Sub Torpedo needs voxel projectiles
@@ -185,7 +185,7 @@ taxi:
 tnkd:
 	idle:
 
-tractor: #Unused
+tractor:
 	idle:
 
 sapc:
@@ -197,14 +197,14 @@ dtruck:
 trucka:
 	idle:
 
-truckb: #Psst Has crates in it :D
+truckb:
 	idle:
 
 ttnk:
 	idle:
 	turret: ttnktur
 
-tug: #Tug Boat
+tug:
 	idle:
 
 v3:
@@ -214,14 +214,14 @@ v3:
 #v3rocket: #V3 Missile needs voxel projectiles
 #	idle:
 
-vlad: #Vladimir's Dreadnought SP unit
+vlad:
 	idle:
 #Needs without weapon image vladwo
 
-wini: #Recreational Vehicle Not sure if used in RA2
+wini:
 	idle:
 
-zep: #Kirov Reporting!
+zep:
 	idle:
 
 #zbomb: #Kirov bomb needs voxel projectiles


### PR DESCRIPTION
Removes several tiny errors/inconsistencies uncovered during the process, too (without introducing any new, I hope).

Closes #101. (Weapons already use inheritance.)

For the record: Civilian infantry will need a rules overhaul in a follow-up.