### PR TITLE
Fix civilian names

### DIFF
--- a/mods/ra2/rules/civilians.yaml
+++ b/mods/ra2/rules/civilians.yaml
@@ -77,6 +77,7 @@ vladimir:
 	Inherits: ^CivilianInfantry
 	Tooltip:
 		Name: Vladimir
+		GenericVisibility: None
 	WithInfantryBody:
 		IdleSequences: idle1, idle2
 
@@ -84,6 +85,7 @@ pentgen:
 	Inherits: ^CivilianInfantry
 	Tooltip:
 		Name: Pentagon General
+		GenericVisibility: None
 	Voiced:
 		VoiceSet: GIVoice
 
@@ -91,8 +93,10 @@ ssrv:
 	Inherits: ^CivilianInfantry
 	Tooltip:
 		Name: Secret Service
+		GenericVisibility: None
 
 pres:
 	Inherits: ^CivilianInfantry
 	Tooltip:
 		Name: President
+		GenericVisibility: None

--- a/mods/ra2/rules/defaults.yaml
+++ b/mods/ra2/rules/defaults.yaml
@@ -725,7 +725,10 @@
 		PlayerExperience: 2
 		Voice: Move
 	Tooltip:
+		Name: Civilian
 		GenericName: Civilian
+		GenericVisibility: Enemy, Ally, Neutral
+		GenericStancePrefix: false
 	Health:
 		HP: 50
 	Mobile:


### PR DESCRIPTION
Supersedes #521.

`Name: Civilian` is needed as some civilians don't have a name assigned to them and would then get an empty tooltip with the visibility cheat enabled.

Closes #411.