### PR TITLE
Add GI sandbag deploy

### DIFF
--- a/OpenRA.Mods.RA2/OpenRA.Mods.RA2.csproj
+++ b/OpenRA.Mods.RA2/OpenRA.Mods.RA2.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Traits\PeriodicExplosion.cs" />
     <Compile Include="Traits\Render\WithExitOverlay.cs" />
     <Compile Include="Traits\Render\WithMindControlArc.cs" />
+    <Compile Include="Traits\Render\WithTurretDeployAnimation.cs" />
   </ItemGroup>
   <Target Name="AfterBuild">
     <MakeDir Directories="$(SolutionDir)mods\ra2\"/>

--- a/OpenRA.Mods.RA2/Traits/Render/WithTurretDeployAnimation.cs
+++ b/OpenRA.Mods.RA2/Traits/Render/WithTurretDeployAnimation.cs
@@ -1,0 +1,71 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Linq;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.Common.Traits.Render;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RA2.Traits.Render
+{
+	public class WithTurretDeployAnimationInfo : ConditionalTraitInfo, Requires<WithSpriteTurretInfo>
+	{
+		[Desc("Turret name")]
+		public readonly string Turret = "primary";
+
+		public readonly string DeploySequence = "deploy";
+		public readonly string UndeploySequence = "undeploy";
+
+		public override object Create(ActorInitializer init)
+		{
+			return new WithTurretDeployAnimation(init.Self, this);
+		}
+	}
+
+	public class WithTurretDeployAnimation : ConditionalTrait<WithTurretDeployAnimationInfo>, INotifyDeployTriggered
+	{
+		readonly WithSpriteTurret wst;
+
+		INotifyDeployComplete[] notifiers;
+
+		public WithTurretDeployAnimation(Actor self, WithTurretDeployAnimationInfo info)
+			: base(info)
+		{
+			wst = self.TraitsImplementing<WithSpriteTurret>()
+				.Single(st => st.Info.Turret == info.Turret);
+		}
+
+		protected override void Created(Actor self)
+		{
+			notifiers = self.TraitsImplementing<INotifyDeployComplete>().ToArray();
+			base.Created(self);
+		}
+
+		void INotifyDeployTriggered.Deploy(Actor self, bool skipMakeAnim)
+		{
+			wst.PlayCustomAnimation(self, Info.DeploySequence, () =>
+			{
+				foreach (var n in notifiers)
+					n.FinishedDeploy(self);
+			});
+		}
+
+		void INotifyDeployTriggered.Undeploy(Actor self, bool skipMakeAnim)
+		{
+			wst.PlayCustomAnimation(self, Info.UndeploySequence, () =>
+			{
+				foreach (var n in notifiers)
+					n.FinishedUndeploy(self);
+			});
+		}
+	}
+}

--- a/mods/ra2/rules/allied-infantry.yaml
+++ b/mods/ra2/rules/allied-infantry.yaml
@@ -122,34 +122,76 @@ e1:
 	Health:
 		HP: 125
 	Mobile:
+		RequiresCondition: !chronodisable && undeployed
 	Passenger:
 		PipType: Green
 	RevealsShroud:
 		Range: 5c0
 	AttackFrontal:
 		Voice: Attack
+		RequiresCondition: !deployed
+	AttackTurreted@deployed:
+		Armaments: deployed, deployed-elite
+		Voice: Attack
+		RequiresCondition: deployed
 	Armament@primary:
 		Weapon: M60
-		RequiresCondition: !rank-elite
+		RequiresCondition: !deployed && !rank-elite
 	Armament@elite:
 		Weapon: M60E
-		RequiresCondition: rank-elite
-	# Armament@deployed:
-	#	Weapon: para
-	#	UpgradeTypes: deployed
-	#	UpgradeMinEnabledLevel: 1
-	# Armament@elite-deployed:
-	#	Weapon: paraE
-	#	UpgradeTypes: eliteparaweapon
-	#	UpgradeMinEnabledLevel: 1
+		RequiresCondition: !deployed && rank-elite
+	Armament@deployed:
+		Name: deployed
+		Weapon: para
+		RequiresCondition: deployed && !rank-elite
+	Armament@elite-deployed:
+		Name: deployed-elite
+		Weapon: paraE
+		RequiresCondition: deployed && rank-elite
 	WithInfantryBody:
 		DefaultAttackSequence: shoot
+		RequiresCondition: undeployed
+	GrantConditionOnDeploy:
+		DeployedCondition: deployed
+		UndeployedCondition: undeployed
+		CanDeployOnRamps: True
+		Facing: 128
+		RequiresCondition: !parachute
+		DeploySound: igidepa.wav # igidepb.wav
+		UndeploySound: igidepa.wav # igidepb.wav
+	# TODO: TakeCover is not yet conditional
+	-TakeCover:
+	Turreted:
+		RealignDelay: -1
+		TurnSpeed: 50
+		InitialFacing: 128
+	WithSpriteTurret:
+		Sequence: deployed
+		RequiresCondition: !undeployed && editorhack
+	WithTurretDeployAnimation:
+	WithTurretAttackAnimation:
+		Sequence: shoot-deployed
+		Armament: deployed
+		RequiresCondition: !undeployed && !rank-elite
+	WithTurretAttackAnimation@elite:
+		Sequence: shoot-deployed
+		Armament: deployed-elite
+		RequiresCondition: !undeployed && rank-elite
+	RejectsOrders@deployment:
+		Reject: Move, EnterTransport, EnterTransports
+		RequiresCondition: deployed
 	Voiced:
 		VoiceSet: GIVoice
 	ProducibleWithLevel:
 		Prerequisites: barracks.infiltrated
 	QuantizeFacingsFromSequence:
 		Sequence: stand
+	# HACK: negated conditions evaluate to true in EnabledByDefault, we can use this duplicate WIB to render it on map editor
+	GrantCondition:
+		Condition: editorhack
+	WithInfantryBody@Editor:
+		DefaultAttackSequence: shoot
+		RequiresCondition: !editorhack
 
 snipe:
 	Inherits: ^Infantry

--- a/mods/ra2/sequences/allied-infantry.yaml
+++ b/mods/ra2/sequences/allied-infantry.yaml
@@ -60,6 +60,9 @@ e1:
 	deploy:
 		Start: 300
 		Length: 15
+	undeploy:
+		Frames: 314, 313, 312, 311, 310, 309, 308, 307, 306, 305, 304, 303, 302, 301, 300
+		Length: 15
 	shoot-deployed:
 		Start: 315
 		Length: 6


### PR DESCRIPTION
Supersedes #497.

Leftover todo (for upstream PRs):
- TakeCover is not conditional (yet)
- GrantConditionOnDeploy doesn't support multiple sounds

This adds a `WithTurretDeployAnimation` that plays the deploy animation so no empty sprite file hack is needed.