### PR TITLE
Added rubble for Airport, Hospital, and Oil Derrick

### DIFF
--- a/mods/ra2/rules/palettes.yaml
+++ b/mods/ra2/rules/palettes.yaml
@@ -53,6 +53,10 @@
 		Tileset: URBAN
 		Filename: liburb.pal
 		ShadowIndex: 1
+	PaletteFromFile@outpost-rubble:
+		Name: outpost-rubble
+		Filename: isosno.pal
+		ShadowIndex: 1
 	PaletteFromFile@playerurb:
 		Name: player
 		Tileset: URBAN

--- a/mods/ra2/rules/tech-structures.yaml
+++ b/mods/ra2/rules/tech-structures.yaml
@@ -25,6 +25,17 @@ caoild:
 		Offset: 1000,0,0
 	GivesCashOnCapture:
 		Amount: 1000
+	SpawnActorOnDeath:
+		Actor: caoild.rubble
+
+caoild.rubble:
+	Inherits: ^Rubble
+	Inherits@shape: ^2x2Shape
+	Building:
+		Dimensions: 2,2
+		Footprint: == ==
+	RenderSprites:
+		Image: caoild
 
 caairp:
 	Inherits: ^TechBuilding
@@ -74,6 +85,17 @@ caairp:
 	WithIdleOverlay@decoration:
 	WithIdleOverlay@flag:
 		Sequence: flag
+	SpawnActorOnDeath:
+		Actor: caairp.rubble
+
+caairp.rubble:
+	Inherits: ^Rubble
+	Inherits@shape: ^3x2Shape
+	Building:
+		Dimensions: 3,3
+		Footprint: === === ===
+	RenderSprites:
+		Image: caairp
 
 cahosp:
 	Inherits: ^TechBuilding
@@ -96,6 +118,17 @@ cahosp:
 	WithIdleOverlay@flag:
 		Sequence: flag
 		Offset: 0,-500,2520
+	SpawnActorOnDeath:
+		Actor: cahosp.rubble
+
+cahosp.rubble:
+	Inherits: ^Rubble
+	Inherits@shape: ^6x4Shape
+	Building:
+		Dimensions: 6,4
+		Footprint: ==== ==== ==== ==== ==== ====
+	RenderSprites:
+		Image: cahosp
 
 cathosp:
 	Inherits: cahosp
@@ -127,6 +160,8 @@ caoutp:
 		FinishRepairingNotification: UnitRepaired
 	WithIdleOverlay@tower:
 		Sequence: idle-tower
+	WithIdleOverlay@tower-shadow:
+		Sequence: idle-tower-shadow
 	WithIdleOverlay@bib:
 		Sequence: bib
 	WithIdleOverlay@flag:
@@ -156,3 +191,15 @@ caoutp:
 	Armament:
 		Weapon: HoverMissile
 		LocalOffset: 500,0,900
+	SpawnActorOnDeath:
+		Actor: caoutp.rubble
+
+caoutp.rubble:
+	Inherits: ^Rubble
+	Inherits@shape: ^4x3Shape
+	Building:
+		Dimensions: 4,3
+		Footprint: ==== ==== ====
+	RenderSprites:
+		Image: caoutp
+		Palette: outpost-rubble

--- a/mods/ra2/sequences/defaults.yaml
+++ b/mods/ra2/sequences/defaults.yaml
@@ -158,6 +158,10 @@
 		ShadowStart: 5
 	flag:
 		Length: 16
+	rubble:
+		Start: 3
+		ShadowStart: 7
+		ZOffset: -3c0
 
 ^CivStructure:
 	Defaults:

--- a/mods/ra2/sequences/tech-structures.yaml
+++ b/mods/ra2/sequences/tech-structures.yaml
@@ -46,10 +46,16 @@ caoutp:
 	Defaults:
 		Offset: -15, -50
 	idle-tower:
-		ShadowStart: 4
+		ShadowStart: -1
 	damaged-idle-tower:
 		Start: 1
-		ShadowStart: 5
+		ShadowStart: -1
+	idle-tower-shadow:
+		UseTilesetCode: false
+		Start: 4
+	damaged-idle-tower-shadow:
+		UseTilesetCode: false
+		Start: 5
 	idle: caoutp_d
 		ShadowStart: 2
 	damaged-idle: caoutp_d
@@ -67,3 +73,5 @@ caoutp:
 	damaged-bib: caoutpbb
 		Start: 1
 	flag: caoutp_f
+	rubble:
+		UseTilesetCode: false


### PR DESCRIPTION
Rubble art added for Airport, Hospital, and Oil Derrick Tech Structures to fix #555. Rubble for the Tech Outpost should be dealt with in #564 due to different numbers of animation frames for each tile set.