### PR TITLE
Remove "Allied" from gaorep's name.

### DIFF
--- a/mods/ra2/rules/allied-structures.yaml
+++ b/mods/ra2/rules/allied-structures.yaml
@@ -766,7 +766,7 @@ gaorep:
 	Valued:
 		Cost: 2500
 	Tooltip:
-		Name: Allied Ore Purifier
+		Name: Ore Purifier
 	Building:
 		Footprint: xxx xxx xxx
 		Dimensions: 3,3


### PR DESCRIPTION
It didn't exist in the original game. It is probably a leftover from the Name: value in the ini, which is "Allied Ore Processor", i remember fixing the "Processor", but didn't remove the "Allied" it seems.