### PR TITLE
Fixed Cloning Vats

### DIFF
--- a/mods/ra2/rules/soviet-structures.yaml
+++ b/mods/ra2/rules/soviet-structures.yaml
@@ -677,13 +677,14 @@ naclon:
 		SpawnOffset: 0,0,0
 		ExitCell: 2, 2
 	Production:
-		Produces: Dummy
+		Produces: Clone
 	RallyPoint:
 		Offset: 3,3
 		Palette: mouse
 		IsPlayerPalette: false
 	ClonesProducedUnits:
 		CloneableTypes: infantry
+		ProductionType: Clone
 	AcceptsDeliveredCash:
 
 napsis:


### PR DESCRIPTION
This yml fix will enable cloning vats to work.

This requires the [bleed](/OpenRA/OpenRA) branch to be used for the engine. It contains the root fix for why cloning vats didn't work.