### PR TITLE
Add Descriptions to Random countries

### DIFF
--- a/mods/ra2/rules/world.yaml
+++ b/mods/ra2/rules/world.yaml
@@ -115,16 +115,19 @@
 		InternalName: Random
 		RandomFactionMembers: random-allies, random-soviets
 		Side: Randoms
+		Description: Random Country\nA random country will be chosen when the game starts.
 	Faction@allies:
 		Name: Allies
 		InternalName: random-allies
 		RandomFactionMembers: america, germany, england, france, korea
 		Side: Randoms
+		Description: Random Allied Country\nA random Allied country will be chosen when the game starts.
 	Faction@soviets:
 		Name: Soviets
 		InternalName: random-soviets
 		RandomFactionMembers: cuba, libya, iraq, russia
 		Side: Randoms
+		Description: Random Soviet Country\nA random Soviet country will be chosen when the game starts.
 	Faction@1:
 		Name: America
 		InternalName: america


### PR DESCRIPTION
This regressed at some point in upstream so when there is no desc, it shows and empty tooltip when hovered over a country (it used to not show anything).

This should be better since randoms has description in the main mods too.