### PR TITLE
Fix Allied War Factory make animation.

### DIFF
--- a/mods/ra2/rules/allied-structures.yaml
+++ b/mods/ra2/rules/allied-structures.yaml
@@ -396,9 +396,10 @@ gaweap:
 		RequiresCondition: !build-incomplete
 	WithIdleOverlay@bib:
 		Sequence: bib
-	WithExitOverlay@top-vehicles:
 		RequiresCondition: !build-incomplete
+	WithExitOverlay@top-vehicles:
 		Sequence: build-top
+		RequiresCondition: !build-incomplete
 	WithExitOverlay@ramp:
 		Sequence: build-ramp
 		RequiresCondition: !build-incomplete


### PR DESCRIPTION
Bib was missing the condition to be disabled during the make animation.