### PR TITLE
Make Ore Purifier work.

### DIFF
--- a/mods/ra2/rules/allied-structures.yaml
+++ b/mods/ra2/rules/allied-structures.yaml
@@ -811,6 +811,8 @@ gaorep:
 	WithIdleOverlay@glow:
 		Sequence: idle-glow
 		RequiresCondition: !build-incomplete
+	ResourcePurifier:
+		Modifier: 25
 	Power:
 		Amount: -200
 


### PR DESCRIPTION
The logic has been in the engine for a while now, but doesn't seem like it was coded to be used by the purifier.

Fixes  #289