### PR TITLE
Change the ability cursor to blue one

### DIFF
--- a/mods/ra2/cursors.yaml
+++ b/mods/ra2/cursors.yaml
@@ -258,11 +258,8 @@ Cursors:
 			Start: 351
 			Length: 5
 		ability:
-			Start: 68
-			Length: 5
-		ability-minimap:
-			Start: 73
-			Length: 5
+			Start: 329
+			Length: 10
 		powerdown-blocked:
 			Start: 342
 		joystick-all:


### PR DESCRIPTION
Currently Guard Cursor is used which doesn't really fit. Minimap version of this doesn't seem to exist in RA2's mouse.shp but it is in YR's one (not sure if it is necesarrily minimap version of this, but it is fitting and seems like we are using it in RV.).