### PR TITLE
Fix macOS packaging errors.

### DIFF
--- a/packaging/osx/buildpackage.sh
+++ b/packaging/osx/buildpackage.sh
@@ -109,7 +109,7 @@ popd > /dev/null
 
 echo "Building mod files"
 make core
-cp -Lr mods/* "${BUILTDIR}/OpenRA.app/Contents/Resources/mods"
+cp -LR mods/* "${BUILTDIR}/OpenRA.app/Contents/Resources/mods"
 
 popd > /dev/null
 

--- a/packaging/osx/buildpackage.sh
+++ b/packaging/osx/buildpackage.sh
@@ -69,7 +69,7 @@ rm "${PACKAGING_OSX_LAUNCHER_TEMP_ARCHIVE_NAME}"
 modify_plist "{DEV_VERSION}" "${TAG}" "${BUILTDIR}/OpenRA.app/Contents/Info.plist"
 modify_plist "{FAQ_URL}" "${PACKAGING_FAQ_URL}" "${BUILTDIR}/OpenRA.app/Contents/Info.plist"
 
-pushd ${TEMPLATE_ROOT} > /dev/null
+pushd "${TEMPLATE_ROOT}" > /dev/null
 
 if [ ! -f "${ENGINE_DIRECTORY}/Makefile" ]; then
 	echo "Required engine files not found."


### PR DESCRIPTION
`cp -Lr` is not supported on macOS Catalina. Use `cp -LR` instead.

Also, Line 72 shall quote the dir. Otherwise, the compilation corrupts when dir contains space.