### PR TITLE
Fixed anti-air flak weapon discrepancies

### DIFF
--- a/mods/ra2/weapons/defaults.yaml
+++ b/mods/ra2/weapons/defaults.yaml
@@ -33,8 +33,9 @@
 ^AAFlak:
 	Inherits: ^Flak
 	Report: vflaat2a.wav, vflaat2b.wav, vflaat2c.wav, vflaat2d.wav
-	-Projectile:
-	Projectile: InstantHit
+	Projectile: Bullet
+		Speed: 100c0
+		Inaccuracy: 128
 	Warhead@1Dam: SpreadDamage
 		Spread: 120
 		ValidTargets: Air

--- a/mods/ra2/weapons/flaks.yaml
+++ b/mods/ra2/weapons/flaks.yaml
@@ -16,8 +16,6 @@ FlakGuyAAGun:
 	Inherits: ^AAFlak
 	Range: 8c0
 	ValidTargets: Air
-	Projectile: Bullet
-		Inaccuracy: 128
 
 FlakGuyAAGunE:
 	Inherits: FlakGuyAAGun


### PR DESCRIPTION
as `InstantHit` does not support inaccuracy.