### PR TITLE
Manually overwrite the AutoTarget ScanRadius for kirovs

### DIFF
--- a/mods/ra2/rules/aircraft.yaml
+++ b/mods/ra2/rules/aircraft.yaml
@@ -112,6 +112,8 @@ zep:
 	AttackFrontal:
 		Voice: Attack
 		FacingTolerance: 128
+	AutoTarget:
+		ScanRadius: 7
 	RenderSprites:
 	RenderVoxels:
 	WithVoxelBody:


### PR DESCRIPTION
Follow-up to #373.
The problem was that the small weapon range of the bomb was used as scan radius for `AutoTarget`. Manually setting a radius avoids this issue.