### PR TITLE
Applied some animation corrections for buildings when player is on low powered.

### DIFF
--- a/mods/ra2/rules/allied-structures.yaml
+++ b/mods/ra2/rules/allied-structures.yaml
@@ -59,7 +59,6 @@ gacnst:
 		ValidPowerStates: Low, Critical
 	WithIdleOverlay@fans:
 		Sequence: idle-fans
-		PauseOnCondition: lowpower
 		RequiresCondition: !build-incomplete
 	WithBuildingPlacedOverlay:
 	ProvidesPrerequisite:
@@ -300,19 +299,15 @@ gaairc:
 		Range: 10c0
 	WithIdleOverlay@top:
 		Sequence: idle-top
-		PauseOnCondition: lowpower
 		RequiresCondition: !build-incomplete
 	WithIdleOverlay@bottom:
 		Sequence: idle-bottom
-		PauseOnCondition: lowpower
 		RequiresCondition: !build-incomplete
 	WithIdleOverlay@mid:
 		Sequence: idle-mid
-		PauseOnCondition: lowpower
 		RequiresCondition: !build-incomplete
 	WithIdleOverlay@lights:
 		Sequence: idle-lights
-		PauseOnCondition: lowpower
 		RequiresCondition: !build-incomplete
 	Targetable:
 		TargetTypes: Ground, C4, DetonateAttack, Structure, SpyInfiltrate
@@ -867,9 +862,13 @@ gaorep:
 		Type: Wood
 	RevealsShroud:
 		Range: 5c0
-	WithIdleOverlay@glow:
+	WithIdleOverlay:
 		Sequence: idle-glow
+		PauseOnCondition: lowpower
 		RequiresCondition: !build-incomplete
+	GrantConditionOnPowerState@LOWPOWER:
+		Condition: lowpower
+		ValidPowerStates: Low, Critical
 	ResourcePurifier:
 		Modifier: 25
 	Power:


### PR DESCRIPTION
Modified the following rules:
1. Allied Construction Yard(gacnst)
2. Allied Airforce Command Headquarters (gaairc)
3. Allied Ore Purifier (gaorep)

Changed constructions yard and airforce command to not pause the animation when it is on low power (This is how it works on the original game)
Changed the ore purifier to halt on animation when it is on low power (This is how it works on the original game)

This pull request is related to the issue filed in #727 