### PR TITLE
Set the working directory for Powershell IO methods

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -233,6 +233,7 @@ function ParseConfigFile($fileName)
 			ReadConfigLine $line $name
 		}
 	}
+	$reader.Close()
 
 	$missing = @()
 	foreach ($name in $names)
@@ -308,7 +309,9 @@ if ($command -eq "all" -or $command -eq "clean")
 	$currentEngine = ""
 	if (Test-Path $versionFile)
 	{
-		$currentEngine = [System.IO.File]::OpenText($versionFile).ReadLine()
+		$reader = [System.IO.File]::OpenText($versionFile)
+		$currentEngine = $reader.ReadLine()
+		$reader.Close()
 	}
 
 	if ($currentEngine -ne "" -and $currentEngine -eq $env:ENGINE_VERSION)

--- a/make.ps1
+++ b/make.ps1
@@ -288,6 +288,10 @@ else
 	$command = $args
 }
 
+# Set the working directory for our IO methods
+$templateDir = $pwd.Path
+[System.IO.Directory]::SetCurrentDirectory($templateDir)
+
 # Load the environment variables from the config file
 # and get the mod ID from the local environment variable
 ParseConfigFile "mod.config"
@@ -304,7 +308,6 @@ $env:MOD_SEARCH_PATHS = (Get-Item -Path ".\" -Verbose).FullName + "\mods,./mods"
 # Run the same command on the engine's make file
 if ($command -eq "all" -or $command -eq "clean")
 {
-	$templateDir = $pwd.Path
 	$versionFile = $env:ENGINE_DIRECTORY + "/VERSION"
 	$currentEngine = ""
 	if (Test-Path $versionFile)


### PR DESCRIPTION
Closes #732.
Apparently `OpenText` is in `System.IO` which has it's own concept of working directory and is the directory you opened Powershell in.