### PR TITLE
vscode: build before launching, launch from engine dir so that build artifacts can be found

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,18 +2,24 @@
 	"version": "0.2.0",
 	"configurations": [
 		{
-			"name": "ra2",
+			"name": "Red Alert 2",
 			"type": "clr",
 			"linux": {
-				"type": "mono"
+				"type": "mono",
 			},
 			"osx": {
-				"type": "mono"
+				"type": "mono",
 			},
 			"request": "launch",
+			"preLaunchTask": "build",
 			"program": "${workspaceRoot}/engine/OpenRA.Game.exe",
-			"cwd": "${workspaceRoot}",
-			"args": ["Engine.LaunchPath=${workspaceRoot}", "Engine.ModSearchPaths=${workspaceRoot}/mods,./mods", "Game.Mod=ra2", "Debug.DisplayDeveloperSettings=true"]
+			"cwd": "${workspaceRoot}/engine/",
+			"args": [
+				"Engine.LaunchPath=${workspaceRoot}",
+				"Engine.ModSearchPaths=${workspaceRoot}/mods,./mods",
+				"Game.Mod=ra2",
+				"Debug.DisplayDeveloperSettings=true",
+			],
 		},
-	]
+	],
 }


### PR DESCRIPTION
like https://github.com/OpenHV/OpenHV/pull/225 but for RA2
closes #753