### PR TITLE
Fix the 155mm report sound

### DIFF
--- a/mods/ra2/weapons/bullets.yaml
+++ b/mods/ra2/weapons/bullets.yaml
@@ -267,7 +267,7 @@ MirageGunE:
 	Inherits: ^LargeBullet
 	ReloadDelay: 110
 	Range: 8c0
-	Report: vdesatta.wav, vrdesattb.wav
+	Report: vdesatta.wav, vdesattb.wav
 	InvalidTargets: Underwater
 	Projectile: Bullet
 		Blockable: false


### PR DESCRIPTION
Testcase: Build some Destroyers and let them shoot. `LoadSound, file does not exist: vrdesattb.wav` will appear in `sound.log`.
The original `sound.ini` also lists `[DestroyerAttack] Sounds= vdesatta vdesattb` and confirmed via XCC Mixer that this is the correct name now.