### PR TITLE
Fix to stop IFV + engineer targeting enemies in aggressive stances

### DIFF
--- a/mods/ra2/rules/allied-vehicles.yaml
+++ b/mods/ra2/rules/allied-vehicles.yaml
@@ -313,7 +313,7 @@ fv:
 		InvalidTargets: NoAutoTarget
 	AutoTargetPriority@REPAIR:
 		RequiresCondition: ifv-repair
-		ValidTargets: Repair
+		ValidTargets: Repair, Ally
 		InvalidTargets: NoAutoTarget
 	AutoTargetPriority@NOBUILDING:
 		RequiresCondition: ifv-deso

--- a/mods/ra2/rules/allied-vehicles.yaml
+++ b/mods/ra2/rules/allied-vehicles.yaml
@@ -313,7 +313,8 @@ fv:
 		InvalidTargets: NoAutoTarget
 	AutoTargetPriority@REPAIR:
 		RequiresCondition: ifv-repair
-		ValidTargets: Repair, Ally
+		ValidTargets: Repair
+		ValidRelationships: Ally
 		InvalidTargets: NoAutoTarget
 	AutoTargetPriority@NOBUILDING:
 		RequiresCondition: ifv-deso


### PR DESCRIPTION
Fixes #769 

This should also stop the IFV + engineer repairing enemy units when using force attack